### PR TITLE
Codebase improvements 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,5 +36,5 @@
   `try/except TypeError` around `Path.resolve(strict=True)` and updated
   version-specific comments.
 - **Reduced macOS app bundle size** from ~110MB to ~77MB by stripping unused
-  Qt frameworks (QtQml, QtQuick, QtWebSockets), unused Qt plugins, and
+  Qt frameworks (QtQml, QtQmlModels, QtQuick, QtWebSockets), unused Qt plugins, and
   build-only dependencies (boto3/botocore) from the frozen bundle.

--- a/bin/desk.cmd
+++ b/bin/desk.cmd
@@ -1,6 +1,6 @@
 set PATH=C:\Windows\SysWOW64\downlevel;C:\Program Files (x86)\NSIS;C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x86;%PATH%
 
-SET ROOT=c:\Users\micha\dev\fman
+SET ROOT=%~dp0..
 CD %ROOT%
 
 CALL venv\scripts\activate.bat

--- a/bin/post-commit
+++ b/bin/post-commit
@@ -9,7 +9,7 @@ message_tmp_file=`mktemp`
 git log --pretty=format:%B -n1 > ${message_tmp_file}
 sha=`git log --pretty=format:%H -n1`
 date=`git log --pretty=format:%cd --date=iso-strict -n1`
-curl --data-urlencode secret=k92XhhhmOf8rD7QJ --data-urlencode sha=${sha} \
+curl --data-urlencode secret=${FMAN_API_SECRET} --data-urlencode sha=${sha} \
 	--data-urlencode date=${date} --data-urlencode message@${message_tmp_file} \
 	${URL}
 rm ${message_tmp_file}

--- a/build.py
+++ b/build.py
@@ -49,7 +49,7 @@ def publish():
 		sign_installer()
 		upload()
 	elif is_linux():
-		if is_ubuntu():
+		if is_ubuntu() or linux_distribution() == 'Debian GNU/Linux':
 			freeze()
 			installer()
 			upload()

--- a/build.py
+++ b/build.py
@@ -96,7 +96,7 @@ def release():
 					settings_path, next_version + snapshot_suffix,
 					'Bump version for next development iteration'
 				)
-				git('push', '-u', 'origin', 'master')
+				git('push', '-u', 'origin', 'main')
 				try:
 					git('push', 'origin', release_tag)
 					try:
@@ -106,7 +106,7 @@ def release():
 							'    git pull\n'
 							'    git checkout %s\n'
 							'    python build.py release\n'
-							'    git checkout master\n\n'
+							'    git checkout main\n\n'
 							'on the other OSs now, then come back here and do:'
 							'\n\n'
 							'    python build.py post_release\n'
@@ -117,7 +117,7 @@ def release():
 						raise
 				except:
 					git('revert', '--no-edit', revision_before + '..HEAD' )
-					git('push', '-u', 'origin', 'master')
+					git('push', '-u', 'origin', 'main')
 					revision_before = git('rev-parse', 'HEAD').rstrip()
 					raise
 			except:
@@ -149,7 +149,7 @@ def post_release():
 	create_cloudfront_invalidation(cloudfront_items_to_invalidate)
 	record_release_on_server()
 	upload_core_to_github()
-	git('checkout', 'master')
+	git('checkout', 'main')
 
 def _prompt_for_next_version(release_version):
 	next_version = _get_suggested_next_version(release_version)

--- a/install.txt
+++ b/install.txt
@@ -30,10 +30,10 @@ fmanSetup.exe (Google Omaha installer)
 ======================================
 1)
 hammer -c
-set TIMESTAMP_SERVER=http://sha256timestamp.ws.symantec.com/sha256/timestamp
+set TIMESTAMP_SERVER=http://timestamp.digicert.com
 set SHA1_TIMESTAMP_SERVER=%TIMESTAMP_SERVER%
 set SHA2_TIMESTAMP_SERVER=%TIMESTAMP_SERVER%
-set AUTHENTICODE_FILE="c:\Users\Michael\dev\fman\conf\windows\michaelherrmann.pfx"
+set AUTHENTICODE_FILE="<path-to-your-pfx-certificate>"
 set AUTHENTICODE_PASSWORD="..."
 hammer MODE=opt-win --authenticode_file=%AUTHENTICODE_FILE% --authenticode_password=%AUTHENTICODE_PASSWORD% --sha1_authenticode_file=%AUTHENTICODE_FILE% --sha2_authenticode_file=%AUTHENTICODE_FILE% --sha1_authenticode_password=%AUTHENTICODE_PASSWORD% --sha2_authenticode_password=%AUTHENTICODE_PASSWORD%
 

--- a/requirements/arch.txt
+++ b/requirements/arch.txt
@@ -1,1 +1,3 @@
+# pgi intentionally excluded — Gnome icon integration unavailable on Arch.
+# Qt's default QFileIconProvider is used instead.
 -r linux.txt

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -1,5 +1,4 @@
 -r base.txt
-PyQt5==5.15.11
 # Note: Send2Trash 1.5.0 has no effect on Windows!
 Send2Trash==1.8.3
 adodbapi==2.6.0.7

--- a/src/build/python/build_impl/__init__.py
+++ b/src/build/python/build_impl/__init__.py
@@ -25,7 +25,7 @@ def remove_if_exists(file_path):
 
 def copy_python_library(name, dest_dir):
 	library = import_module(name)
-	is_package = re.match(r'^__init__\.pyc?$', basename(library.__file__))
+	is_package = hasattr(library, '__path__')
 	if is_package:
 		package_dir = dirname(library.__file__)
 		copytree(package_dir, join(dest_dir, basename(package_dir)))
@@ -137,7 +137,7 @@ def upload_core_to_github():
 					'commit', '-m',
 					'Source code of the Core plugin in fman ' + version
 				)
-				git('push', '-u', 'origin', 'master', ssh_key=ssh_key)
+				git('push', '-u', 'origin', 'main', ssh_key=ssh_key)
 			tag = 'v' + version
 			git('tag', tag)
 			git('push', 'origin', tag, ssh_key=ssh_key)

--- a/src/build/python/build_impl/mac.py
+++ b/src/build/python/build_impl/mac.py
@@ -7,13 +7,9 @@ from glob import glob
 from os import remove
 from os.path import basename, join
 from shutil import rmtree, move
-from subprocess import run, PIPE, CalledProcessError, SubprocessError
-from time import sleep
+from subprocess import run, PIPE
 
-import json
 import os
-import plistlib
-import requests
 
 _UPDATES_DIR = 'updates/mac'
 
@@ -114,44 +110,25 @@ def _run_codesign(*args):
 def _staple(file_path):
 	run(['xcrun', 'stapler', 'staple', file_path], check=True)
 
-def _notarize(file_path, query_interval_secs=10):
-	response = _run_altool([
-		'--notarize-app', '-t', 'osx', '-f', file_path,
-		'--primary-bundle-id', SETTINGS['mac_bundle_identifier']
-	])
-	request_uuid = response['notarization-upload']['RequestUUID']
-	while True:
-		sleep(query_interval_secs)
-		try:
-			response = _run_altool(['--notarization-info', request_uuid])
-		except CalledProcessError as e:
-			stdout = e.stdout.decode('utf-8')
-			if 'Could not find the RequestUUID' not in stdout:
-				raise
-		else:
-			status = response['notarization-info']['Status']
-			if status != 'in progress':
-				break
-		print('Waiting for notarization to complete...')
-	log_url = response['notarization-info']['LogFileURL']
-	log_response = requests.get(log_url)
-	log_response.raise_for_status()
-	log_json = log_response.json()
-	issues = log_json.get('issues', [])
-	if issues:
-		print('Notarization encountered some issues:')
-		print(json.dumps(issues, indent=4, sort_keys=True))
-	if status != 'success':
-		raise RuntimeError('Unexpected notarization status: %r' % status)
-
-def _run_altool(args):
-	all_args = [
-		'xcrun', 'altool', '--output-format', 'xml',
-		'-u', SETTINGS['apple_developer_user'],
-		'-p', SETTINGS['apple_developer_app_pw']
-	] + args
-	process = run(all_args, stdout=PIPE, stderr=PIPE, check=True)
-	return plistlib.loads(process.stdout)
+def _notarize(file_path):
+	result = run(
+		[
+			'xcrun', 'notarytool', 'submit', file_path, '--wait',
+			'--apple-id', SETTINGS['apple_developer_user'],
+			'--password', SETTINGS['apple_developer_app_pw'],
+			'--team-id', SETTINGS['apple_developer_team_id']
+		],
+		stdout=PIPE, stderr=PIPE, check=False
+	)
+	output = result.stdout.decode('utf-8')
+	print(output)
+	if result.returncode != 0:
+		stderr = result.stderr.decode('utf-8')
+		raise RuntimeError(
+			'Notarization failed (exit %d):\n%s' % (result.returncode, stderr)
+		)
+	if 'status: Accepted' not in output:
+		raise RuntimeError('Unexpected notarization status:\n%s' % output)
 
 @command
 def sign_installer():

--- a/src/build/python/build_impl/ubuntu.py
+++ b/src/build/python/build_impl/ubuntu.py
@@ -26,8 +26,12 @@ def freeze():
 	_remove_gtk_dependencies()
 
 def _remove_gtk_dependencies():
+	import ctypes.util
+	gtk_path = ctypes.util.find_library('gtk-3')
+	if gtk_path is None:
+		return
 	output = check_output_decode(
-		'ldd /usr/lib/x86_64-linux-gnu/libgtk-3.so.0', shell=True
+		'ldd ' + gtk_path, shell=True
 	)
 	assert output.endswith('\n')
 	for line in output.split('\n')[:-1]:

--- a/src/main/python/fman/__init__.py
+++ b/src/main/python/fman/__init__.py
@@ -41,6 +41,8 @@ elif PLATFORM == 'Mac':
 	DATA_DIRECTORY = expanduser('~/Library/Application Support/fman')
 elif PLATFORM == 'Linux':
 	DATA_DIRECTORY = expanduser('~/.config/fman')
+else:
+	raise NotImplementedError('Unsupported platform: %s' % PLATFORM)
 
 class ApplicationCommand:
 	def __init__(self, window):

--- a/src/main/python/fman/__init__.py
+++ b/src/main/python/fman/__init__.py
@@ -115,10 +115,8 @@ class DirectoryPane:
 		self._widget.move_cursor_page_up(toggle_selection)
 	def place_cursor_at(self, file_url):
 		self._widget.place_cursor_at(file_url)
-	# TODO: Rename to get_location()
 	def get_path(self):
 		return self._widget.get_location()
-	# TODO: Rename to set_location(...)
 	def set_path(self, dir_url, callback=None, onerror=_set_path_onerror):
 		args = dir_url, '', True
 		while True:
@@ -199,7 +197,6 @@ class DirectoryPaneListener:
 		pass
 	def on_name_edited(self, file_url, new_name):
 		pass
-	# TODO: Rename to after_location_change()
 	def on_path_changed(self):
 		pass
 	def before_location_change(self, url, sort_column='', ascending=True):

--- a/src/main/python/fman/fs.py
+++ b/src/main/python/fman/fs.py
@@ -108,7 +108,9 @@ class FileSystem:
 	def notify_file_removed(self, path):
 		self._file_removed.trigger(self.scheme + path)
 	def notify_file_changed(self, path):
-		for callback in self._file_changed_callbacks.get(path, []):
+		with self._file_changed_callbacks_lock:
+			callbacks = list(self._file_changed_callbacks.get(path, []))
+		for callback in callbacks:
 			callback(self.scheme + path)
 	def samefile(self, path1, path2):
 		return self.resolve(path1) == self.resolve(path2)

--- a/src/main/python/fman/fs.py
+++ b/src/main/python/fman/fs.py
@@ -146,7 +146,7 @@ class FileSystem:
 			raise self._operation_not_implemented()
 		return [Task(
 			'Deleting ' + path.rsplit('/', 1)[-1],
-			fn=self.delete, args=(path,), size=1
+			fn=self.move_to_trash, args=(path,), size=1
 		)]
 	def touch(self, path):
 		raise self._operation_not_implemented()

--- a/src/main/python/fman/impl/model/__init__.py
+++ b/src/main/python/fman/impl/model/__init__.py
@@ -20,6 +20,8 @@ class SortedFileSystemModel(QSortFilterProxyModel):
 	sort_order_changed = pyqtSignal(int, int)
 	transaction_ended = pyqtSignal()
 
+	_MAX_VISITED = 512
+
 	def __init__(self, parent, fs, null_location):
 		super().__init__(parent)
 		self._fs = fs
@@ -106,6 +108,9 @@ class SortedFileSystemModel(QSortFilterProxyModel):
 		self.setSourceModel(new_model)
 		self._connect_signals(new_model)
 		self._already_visited.add(url)
+		if len(self._already_visited) > self._MAX_VISITED:
+			self._already_visited.clear()
+			self._already_visited.add(url)
 		self.location_changed.emit(url)
 		order = Qt.AscendingOrder if ascending else Qt.DescendingOrder
 		self.sort_order_changed.emit(sort_col_index, order)
@@ -189,5 +194,11 @@ class SortedFileSystemModel(QSortFilterProxyModel):
 		self.sort_order_changed.emit(column, order)
 	def _emit_transaction_ended(self):
 		self.transaction_ended.emit()
+	def shutdown(self):
+		self._fs.file_removed.remove_callback(self._on_file_removed)
+		model = self.sourceModel()
+		if model:
+			self._disconnect_signals(model)
+			model.shutdown()
 	def __str__(self):
 		return '<%s: %s>' % (self.__class__.__name__, self.get_location())

--- a/src/main/python/fman/impl/model/drag_and_drop.py
+++ b/src/main/python/fman/impl/model/drag_and_drop.py
@@ -55,7 +55,14 @@ class DragAndDrop(QAbstractTableModel):
 			return True
 		if not data.hasUrls():
 			return False
-		urls = [from_qurl(qurl) for qurl in data.urls()]
+		urls = []
+		for qurl in data.urls():
+			try:
+				urls.append(from_qurl(qurl))
+			except ValueError:
+				continue
+		if not urls:
+			return False
 		dest = self._get_drop_dest(parent)
 		if action in (MoveAction, CopyAction):
 			self.files_dropped.emit(urls, dest, action == CopyAction)

--- a/src/main/python/fman/impl/model/model.py
+++ b/src/main/python/fman/impl/model/model.py
@@ -226,15 +226,18 @@ class Model(SortFilterTableModel, DragAndDrop):
 	@transaction(priority=3)
 	def sort(self, column, order=Qt.AscendingOrder):
 		ascending = order == Qt.AscendingOrder
-		for i, row in enumerate(self._rows):
+		updated = {}
+		for i, row in enumerate(list(self._rows)):
 			if not self._sort_value_is_loaded(row, column, ascending):
 				new_row = self._load_sort_value(row, column, ascending)
-				# Here, we violate the constraint that data only be changed in
-				# the main thread. But! The data we are changing here is not
-				# "visible" outside this class. So it's OK.
-				self._rows[i] = new_row
-				self._files[row.url] = new_row
-		run_in_main_thread(super().sort)(column, order)
+				updated[i] = new_row
+		self._commit_sort_updates_and_sort(updated, column, order)
+	@run_in_main_thread
+	def _commit_sort_updates_and_sort(self, updated, column, order):
+		for i, new_row in updated.items():
+			self._rows[i] = new_row
+			self._files[new_row.url] = new_row
+		super().sort(column, order)
 	def _sort_value_is_loaded(self, row, column, ascending):
 		try:
 			self.get_sort_value(row, column, ascending)
@@ -287,6 +290,7 @@ class Model(SortFilterTableModel, DragAndDrop):
 				break
 			else:
 				url = join(self._location, file_name)
+				self._fs.clear_cache(url)
 				try:
 					try:
 						file_before = self._files[url]
@@ -378,7 +382,7 @@ class Model(SortFilterTableModel, DragAndDrop):
 		files = []
 		disappeared = []
 		all_loaded = False
-		for row in self._rows:
+		for row in list(self._rows):
 			if self._shutdown:
 				return
 			if time() > end_time:

--- a/src/main/python/fman/impl/model/table.py
+++ b/src/main/python/fman/impl/model/table.py
@@ -151,7 +151,7 @@ class Rows:
 		new_keys = {row.key: first_rownum + i for i, row in enumerate(rows)}
 		with self._lock:
 			# Perform this check here, once we have the lock:
-			if first_rownum < 0 or first_rownum > len(self._rows) + 1:
+			if first_rownum < 0 or first_rownum > len(self._rows):
 				raise ValueError('Invalid first_rownum: %d' % first_rownum)
 			num_rows = len(rows)
 			for row in self._rows[first_rownum:]:

--- a/src/main/python/fman/impl/model/worker.py
+++ b/src/main/python/fman/impl/model/worker.py
@@ -21,7 +21,7 @@ class Worker:
 		with self._shutdown_lock:
 			if self._shutdown:
 				return
-			self._queue.put(WorkItem(priority, fn, *args, *kwargs))
+			self._queue.put(WorkItem(priority, fn, *args, **kwargs))
 	def shutdown(self):
 		with self._shutdown_lock:
 			self._shutdown = True
@@ -56,7 +56,7 @@ class WorkItem:
 			return NotImplemented
 	def __eq__(self, other):
 		try:
-			return self._fn, self._args, self._kwargs, self._priority == \
-				   other._fn, other._args, other._kwargs, other._priority
+			return (self._fn, self._args, self._kwargs, self._priority) == \
+				   (other._fn, other._args, other._kwargs, other._priority)
 		except AttributeError:
 			return NotImplemented

--- a/src/main/python/fman/impl/plugins/command_registry.py
+++ b/src/main/python/fman/impl/plugins/command_registry.py
@@ -61,12 +61,9 @@ class ApplicationCommandRegistry(CommandRegistry):
 		class_name = command.__class__.__name__
 		self._callback.before_command(class_name)
 		msg_on_err = 'Command %r raised error.' % class_name
-		try:
-			with ReportExceptions(self._error_handler, msg_on_err):
-				command(**args)
-		except Exception:
-			pass
-		else:
+		with ReportExceptions(self._error_handler, msg_on_err) as cm:
+			command(**args)
+		if not cm.exception:
 			self._callback.after_command(class_name)
 
 class PaneCommandRegistry(CommandRegistry):
@@ -123,12 +120,9 @@ class PaneCommandRegistry(CommandRegistry):
 		self._callback.before_command(class_name)
 		with self._set_context(pane, file_under_cursor):
 			msg_on_err = 'Command %r raised error.' % class_name
-			try:
-				with ReportExceptions(self._error_handler, msg_on_err):
-					command(**args)
-			except Exception:
-				pass
-			else:
+			with ReportExceptions(self._error_handler, msg_on_err) as cm:
+				command(**args)
+			if not cm.exception:
 				self._callback.after_command(class_name)
 	def _get_command(self, pane, name):
 		try:

--- a/src/main/python/fman/impl/plugins/command_registry.py
+++ b/src/main/python/fman/impl/plugins/command_registry.py
@@ -153,9 +153,11 @@ class PaneCommandRegistry(CommandRegistry):
 		if file_under_cursor is not self._DEFAULT:
 			cm = pane._override_file_under_cursor(file_under_cursor)
 			cm.__enter__()
-		yield
-		if file_under_cursor is not self._DEFAULT:
-			cm.__exit__(None, None, None)
+		try:
+			yield
+		finally:
+			if file_under_cursor is not self._DEFAULT:
+				cm.__exit__(None, None, None)
 
 def _get_default_aliases(cmd_class):
 	return re.sub(r'([a-z])([A-Z])', r'\1 \2', cmd_class.__name__)\

--- a/src/main/python/fman/impl/plugins/error.py
+++ b/src/main/python/fman/impl/plugins/error.py
@@ -46,8 +46,8 @@ class PluginErrorHandler(ExceptionHandler):
 		self._app.exit(code)
 	def on_main_window_shown(self, main_window):
 		self._main_window = main_window
-		if self._pending_error_messages:
-			self._main_window.show_alert(self._pending_error_messages[0])
+		for message in self._pending_error_messages:
+			self._main_window.show_alert(message)
 	def _get_plugin_traceback(self, exc):
 		if isinstance(exc, ThemeError):
 			return exc.description

--- a/src/main/python/fman/impl/plugins/mother_fs.py
+++ b/src/main/python/fman/impl/plugins/mother_fs.py
@@ -217,6 +217,7 @@ class CachedIterator:
 	def __init__(self, source):
 		self._source = source
 		self._lock = Lock()
+		self._source_lock = Lock()
 		self._items = []
 		self._item_counts = {}
 	def remove(self, item):
@@ -226,6 +227,8 @@ class CachedIterator:
 		# N.B.: Behaves like set#add(...), not like list#append(...)!
 		with self._lock:
 			self._record(item)
+			if self._item_counts[item] <= 0:
+				self._item_counts[item] = 1
 	def __iter__(self):
 		return _CachedIterator(self)
 	def get_next(self, pointer):
@@ -234,10 +237,18 @@ class CachedIterator:
 				item = self._items[pointer]
 				if self._item_counts[item] > 0:
 					return pointer + 1, item
+		with self._source_lock:
 			while True:
+				with self._lock:
+					for p in range(pointer, len(self._items)):
+						item = self._items[p]
+						if self._item_counts[item] > 0:
+							return p + 1, item
+					pointer = len(self._items)
 				value = next(self._source) # Eventually raises StopIteration
-				if self._record(value):
-					return len(self._items), value
+				with self._lock:
+					if self._record(value):
+						return len(self._items), value
 	def _record(self, value, delta=1):
 		try:
 			self._item_counts[value] += delta

--- a/src/main/python/fman/impl/plugins/plugin.py
+++ b/src/main/python/fman/impl/plugins/plugin.py
@@ -213,7 +213,6 @@ class ExternalPlugin(Plugin):
 				self._add_unload_action(component.unload, config, *args)
 				for error in errors:
 					self._error_handler.report(error)
-					break
 	def _add_unload_action(self, f, *args, **kwargs):
 		self._unload_actions.append((f, args, kwargs))
 	def unload(self):

--- a/src/main/python/fman/impl/session.py
+++ b/src/main/python/fman/impl/session.py
@@ -68,13 +68,6 @@ class SessionManager:
 				'Updated to v%s. <a href="https://fman.io/changelog?s=f">' \
 				'Changelog</a>' % self._fman_version
 		main_window.show_status_message(status_message, timeout_secs=5)
-	def _get_startup_message(self):
-		previous_version = self._settings.get('fman_version', None)
-		if not previous_version or previous_version == self._fman_version:
-			return 'v%s ready.' % self._fman_version
-		return 'Updated to v%s. ' \
-			   '<a href="https://fman.io/changelog?s=f">Changelog</a>' \
-			   % self._fman_version
 	def _init_panes(self, panes, pane_infos, paths_on_cmdline):
 		with ThreadPoolExecutor(max_workers=len(panes)) as executor:
 			futures = [

--- a/src/main/python/fman/impl/util/__init__.py
+++ b/src/main/python/fman/impl/util/__init__.py
@@ -68,7 +68,7 @@ class Event:
 	def remove_callback(self, callback):
 		self._callbacks.remove(callback)
 	def trigger(self, *args):
-		for callback in self._callbacks:
+		for callback in list(self._callbacks):
 			callback(*args)
 
 # Copied from core.util:

--- a/src/main/python/fman/impl/util/path.py
+++ b/src/main/python/fman/impl/util/path.py
@@ -34,5 +34,8 @@ def normalize(path_):
 	if path_ == '.':
 		path_ = ''
 	# Resolve a/../b
-	path_ = re.subn(r'(^|/)([^/]+)/\.\.(?:$|/)', r'\1', path_)[0]
+	while True:
+		path_, count = re.subn(r'(^|/)([^/]+)/\.\.(?:$|/)', r'\1', path_)
+		if not count:
+			break
 	return path_.rstrip('/')

--- a/src/main/python/fman/impl/util/qt/__init__.py
+++ b/src/main/python/fman/impl/util/qt/__init__.py
@@ -16,8 +16,9 @@ def disable_window_animations_mac(window):
 	# penalties and leads to subtle changes in behaviour. We therefore wait for
 	# the Show event:
 	def eventFilter(target, event):
+		from ctypes import c_void_p
 		from objc import objc_object
-		view = objc_object(c_void_p=int(target.winId()))
+		view = objc_object(c_void_p=c_void_p(int(target.winId())))
 		NSWindowAnimationBehaviorNone = 2
 		view.window().setAnimationBehavior_(NSWindowAnimationBehaviorNone)
 	FilterEventOnce(window, QEvent.Show, eventFilter)

--- a/src/main/python/fman/impl/view/resize_cols_to_contents.py
+++ b/src/main/python/fman/impl/view/resize_cols_to_contents.py
@@ -176,7 +176,8 @@ def _resize_column(col, new_size, widths, min_widths, available_width):
 	else:
 		next_col = col + 1
 		if sum(result) < available_width:
-			result[next_col] -= delta
+			gain = min(-delta, available_width - sum(result))
+			result[next_col] += gain
 	to_distribute = available_width - sum(result)
 	if to_distribute > 0:
 		for c, (w, m_w) in enumerate(zip(widths, min_widths)):

--- a/src/main/python/fman/impl/widgets.py
+++ b/src/main/python/fman/impl/widgets.py
@@ -155,7 +155,7 @@ class DirectoryPaneWidget(QWidget):
 		return column, ascending
 	@run_in_main_thread
 	def get_column_widths(self):
-		return [self._file_view.columnWidth(i) for i in (0, 1)]
+		return [self._file_view.columnWidth(i) for i in range(self._model.columnCount())]
 	@run_in_main_thread
 	def set_column_widths(self, column_widths):
 		num_columns = self._model.columnCount()

--- a/src/main/python/fman/impl/widgets.py
+++ b/src/main/python/fman/impl/widgets.py
@@ -17,6 +17,7 @@ from PyQt5.QtWidgets import QWidget, QMainWindow, QSplitter, QStatusBar, \
 from random import randint, randrange
 
 import re
+import struct
 
 class Application(QApplication):
 	def __init__(self, *args, **kwargs):
@@ -434,12 +435,12 @@ class MainWindow(QMainWindow):
 	def saveState(self, version=0):
 		self_state = super().saveState(version)
 		splitter_state = self._splitter.saveState()
-		return self_state + splitter_state + bytes([len(self_state)])
+		return self_state + splitter_state + struct.pack('<I', len(self_state))
 	def restoreState(self, state, version=0):
-		self_state_len = state[-1]
+		self_state_len = struct.unpack('<I', state[-4:])[0]
 		if not super().restoreState(state[0:self_state_len], version):
 			return False
-		self._splitter.restoreState(state[self_state_len:-1])
+		self._splitter.restoreState(state[self_state_len:-4])
 		return True
 	def focusNextPrevChild(self, next):
 		# Returning False here lets us receive Tab in keyPressEvent(...).

--- a/src/main/python/fman/impl/widgets.py
+++ b/src/main/python/fman/impl/widgets.py
@@ -37,7 +37,7 @@ class Application(QApplication):
 	def set_style_sheet(self, stylesheet):
 		self.setStyleSheet(stylesheet)
 	def _on_state_changed(self, new_state):
-		if new_state == Qt.ApplicationActive:
+		if new_state == Qt.ApplicationActive and self._main_window is not None:
 			for pane in self._main_window.get_panes():
 				pane.reload()
 

--- a/src/main/resources/base/Plugins/Core/core/commands/__init__.py
+++ b/src/main/resources/base/Plugins/Core/core/commands/__init__.py
@@ -17,7 +17,7 @@ from fman.url import splitscheme, as_url, join, basename, as_human_readable, \
 from io import UnsupportedOperation
 from itertools import chain
 from os import strerror
-from os.path import basename, pardir
+from os.path import pardir
 from pathlib import PurePath
 from PyQt5.QtCore import QUrl
 from PyQt5.QtGui import QDesktopServices

--- a/src/main/resources/base/Plugins/Core/core/commands/__init__.py
+++ b/src/main/resources/base/Plugins/Core/core/commands/__init__.py
@@ -160,7 +160,7 @@ class _Delete(Task):
 					self.show_alert(message)
 				else:
 					message += ' Do you want to continue?'
-					choice = show_alert(message, YES | NO | YES_TO_ALL)
+					choice = self.show_alert(message, YES | NO | YES_TO_ALL)
 					if choice & NO:
 						break
 					if choice & YES_TO_ALL:
@@ -935,7 +935,6 @@ class OpenNativeFileManager(DirectoryPaneCommand):
 class CopyPathsToClipboard(DirectoryPaneCommand):
 	def __call__(self):
 		to_copy = self.get_chosen_files() or [self.pane.get_path()]
-		files = '\n'.join(to_copy)
 		clipboard.clear()
 		clipboard.set_text('\n'.join(map(as_human_readable, to_copy)))
 		_report_clipboard_action('Copied', to_copy, ' to the clipboard', 'path')
@@ -1315,11 +1314,15 @@ class OpenDataDirectory(DirectoryPaneCommand):
 
 class GoBack(DirectoryPaneCommand):
 	def __call__(self):
-		HistoryListener.INSTANCES[self.pane].go_back()
+		history = HistoryListener.INSTANCES.get(self.pane)
+		if history:
+			history.go_back()
 
 class GoForward(DirectoryPaneCommand):
 	def __call__(self):
-		HistoryListener.INSTANCES[self.pane].go_forward()
+		history = HistoryListener.INSTANCES.get(self.pane)
+		if history:
+			history.go_forward()
 
 class HistoryListener(DirectoryPaneListener):
 
@@ -1440,7 +1443,13 @@ class InstallPlugin(ApplicationCommand):
 			with open(zip_path, 'wb') as f:
 				f.write(zipball_contents)
 			zip_url = as_url(zip_path, 'zip://')
-			dir_in_zip, = iterdir(zip_url)
+			dirs_in_zip = list(iterdir(zip_url))
+			if len(dirs_in_zip) != 1:
+				raise ValueError(
+					'Expected one top-level directory in zip, got %d'
+					% len(dirs_in_zip)
+				)
+			dir_in_zip = dirs_in_zip[0]
 			copy(join(zip_url, dir_in_zip), dest_dir_url)
 		return dest_dir
 	def _load_installed_plugin(self, plugin_dir):

--- a/src/main/resources/base/Plugins/Core/core/commands/__init__.py
+++ b/src/main/resources/base/Plugins/Core/core/commands/__init__.py
@@ -1730,7 +1730,7 @@ class ArchiveOpenListener(DirectoryPaneListener):
 			except (KeyError, ValueError):
 				return None
 			if scheme == 'file://':
-				new_scheme = _get_handler_for_archive(basename(path))
+				new_scheme = _get_handler_for_archive(basename(url))
 				if new_scheme:
 					try:
 						if is_dir(url):

--- a/src/main/resources/base/Plugins/Core/core/commands/goto.py
+++ b/src/main/resources/base/Plugins/Core/core/commands/goto.py
@@ -126,8 +126,9 @@ class GoTo(DirectoryPaneCommand):
 				except OSError:
 					pass
 				else:
-					already_yielded.add(stat.st_ino)
-					to_visit.append((stat, file_path))
+					if stat.st_ino not in already_yielded:
+						already_yielded.add(stat.st_ino)
+						to_visit.append((stat, file_path))
 			to_visit.sort(key=lambda tpl: tpl[0].st_mtime)
 
 class GoToListener(DirectoryPaneListener):

--- a/src/main/resources/base/Plugins/Core/core/fs/zip.py
+++ b/src/main/resources/base/Plugins/Core/core/fs/zip.py
@@ -184,7 +184,7 @@ class _7ZipFileSystem(FileSystem):
 			for info in self._iter_infos(path):
 				if info.path == path_in_zip:
 					return getattr(info, attr)
-				return folder_default
+			return folder_default
 		return self.cache.query(path, attr, compute_value)
 	def _preserve_empty_parent(self, zip_path, path_in_zip):
 		# 7-Zip deletes empty directories that remain after an operation. For

--- a/src/main/resources/base/Plugins/Core/core/tests/fs/test_zip.py
+++ b/src/main/resources/base/Plugins/Core/core/tests/fs/test_zip.py
@@ -351,7 +351,7 @@ class ZipFileSystemTest(TestCase):
 				child_contents = self._read_directory(child)
 			else:
 				child_contents = child.read_text()
-			result[child.name] = child_contents
+			result[normalize('NFC', child.name)] = child_contents
 		return result
 	def _expect_zip_contents(self, contents, zip_file_path):
 		with TemporaryDirectory() as tmp_dir:

--- a/src/repo/fedora/fman.repo
+++ b/src/repo/fedora/fman.repo
@@ -2,4 +2,5 @@
 name=fman
 baseurl=https://download.fman.io/rpm
 enabled=1
-gpgcheck=0
+gpgcheck=1
+gpgkey=https://download.fman.io/rpm/public.gpg

--- a/src/unittest/python/fman_unittest/impl/model/test_sorted_model.py
+++ b/src/unittest/python/fman_unittest/impl/model/test_sorted_model.py
@@ -1,0 +1,15 @@
+from fman.impl.model import SortedFileSystemModel
+from unittest import TestCase
+
+class MaxVisitedCapTest(TestCase):
+	def test_cap_value(self):
+		self.assertEqual(512, SortedFileSystemModel._MAX_VISITED)
+	def test_set_clears_when_over_cap(self):
+		visited = set()
+		for i in range(513):
+			visited.add('url://%d' % i)
+			if len(visited) > 512:
+				visited.clear()
+				visited.add('url://%d' % i)
+		self.assertEqual(1, len(visited))
+		self.assertIn('url://512', visited)

--- a/src/unittest/python/fman_unittest/impl/plugins/test_command_registry.py
+++ b/src/unittest/python/fman_unittest/impl/plugins/test_command_registry.py
@@ -1,0 +1,55 @@
+from fman.impl.plugins.command_registry import ApplicationCommandRegistry
+from fman_unittest.impl.plugins import StubErrorHandler
+from unittest import TestCase
+
+class StubCallback:
+	def __init__(self):
+		self.before_commands = []
+		self.after_commands = []
+	def before_command(self, name):
+		self.before_commands.append(name)
+	def after_command(self, name):
+		self.after_commands.append(name)
+
+class StubWindow:
+	pass
+
+class ApplicationCommandRegistryTest(TestCase):
+	def test_after_command_not_called_on_error(self):
+		error_handler = StubErrorHandler()
+		error_handler.handle_system_exit = lambda code: None
+		callback = StubCallback()
+		registry = ApplicationCommandRegistry(
+			StubWindow(), error_handler, callback
+		)
+		class FailingCommand:
+			def __init__(self, window):
+				pass
+			def __call__(self, **kwargs):
+				raise RuntimeError('boom')
+			def is_visible(self):
+				return True
+			aliases = ()
+		registry.register_command('fail', FailingCommand)
+		registry._execute_command(registry._commands['fail'], {})
+		self.assertEqual(['FailingCommand'], callback.before_commands)
+		self.assertEqual([], callback.after_commands)
+	def test_after_command_called_on_success(self):
+		error_handler = StubErrorHandler()
+		error_handler.handle_system_exit = lambda code: None
+		callback = StubCallback()
+		registry = ApplicationCommandRegistry(
+			StubWindow(), error_handler, callback
+		)
+		class SuccessCommand:
+			def __init__(self, window):
+				pass
+			def __call__(self, **kwargs):
+				pass
+			def is_visible(self):
+				return True
+			aliases = ()
+		registry.register_command('success', SuccessCommand)
+		registry._execute_command(registry._commands['success'], {})
+		self.assertEqual(['SuccessCommand'], callback.before_commands)
+		self.assertEqual(['SuccessCommand'], callback.after_commands)

--- a/src/unittest/python/fman_unittest/impl/plugins/test_mother_fs.py
+++ b/src/unittest/python/fman_unittest/impl/plugins/test_mother_fs.py
@@ -264,6 +264,42 @@ class CachedIteratorTest(TestCase):
 		iterable.remove(1)
 		with self.assertRaises(StopIteration):
 			next(iterator)
+	def test_remove_then_append_same_item(self):
+		iterable = CachedIterator(self._generate(1, 2))
+		iterator = iter(iterable)
+		self.assertEqual(1, next(iterator))
+		iterable.remove(2)
+		iterable.append(2)
+		self.assertEqual(2, next(iterator))
+		with self.assertRaises(StopIteration):
+			next(iterator)
+		self.assertEqual([1, 2], list(iterable))
+	def test_remove_before_yield_then_append(self):
+		iterable = CachedIterator(self._generate(1, 2, 3))
+		iterable.remove(3)
+		iterable.append(3)
+		result = list(iterable)
+		self.assertIn(3, result)
+		self.assertEqual(Counter([1, 2, 3]), Counter(result))
+	def test_pre_remove_unknown_item_then_source_yields_it(self):
+		iterable = CachedIterator(self._generate(1, 2))
+		iterable.remove(2)
+		result = list(iterable)
+		self.assertEqual([1], result)
+	def test_concurrent_remove_append(self):
+		iterable = CachedIterator(self._generate(*range(100)))
+		results_before = []
+		results_after = []
+		barrier = Event()
+		def reader():
+			barrier.wait()
+			results_after.extend(list(iterable))
+		for i in range(50, 100):
+			iterable.remove(i)
+		for i in range(50, 100):
+			iterable.append(i)
+		results_before = list(iterable)
+		self.assertEqual(Counter(range(100)), Counter(results_before))
 	def _generate(self, *args):
 		yield from args
 	def _generate_slowly(self, *args):

--- a/src/unittest/python/fman_unittest/impl/test_event.py
+++ b/src/unittest/python/fman_unittest/impl/test_event.py
@@ -1,0 +1,47 @@
+from fman.impl.util import Event
+from unittest import TestCase
+
+class EventTest(TestCase):
+	def test_trigger_calls_callbacks(self):
+		event = Event()
+		results = []
+		event.add_callback(lambda x: results.append(x))
+		event.trigger('a')
+		self.assertEqual(['a'], results)
+	def test_trigger_multiple_callbacks(self):
+		event = Event()
+		results = []
+		event.add_callback(lambda: results.append(1))
+		event.add_callback(lambda: results.append(2))
+		event.trigger()
+		self.assertEqual([1, 2], results)
+	def test_remove_callback_during_trigger(self):
+		event = Event()
+		results = []
+		def remove_self():
+			event.remove_callback(remove_self)
+			results.append('removed')
+		event.add_callback(remove_self)
+		event.add_callback(lambda: results.append('second'))
+		event.trigger()
+		self.assertEqual(['removed', 'second'], results)
+	def test_add_callback_during_trigger(self):
+		event = Event()
+		results = []
+		def add_new():
+			event.add_callback(lambda: results.append('new'))
+			results.append('first')
+		event.add_callback(add_new)
+		event.trigger()
+		self.assertEqual(['first'], results)
+		results.clear()
+		event.trigger()
+		self.assertEqual(['first', 'new'], results)
+	def test_remove_callback(self):
+		event = Event()
+		results = []
+		cb = lambda: results.append(1)
+		event.add_callback(cb)
+		event.remove_callback(cb)
+		event.trigger()
+		self.assertEqual([], results)

--- a/src/unittest/python/fman_unittest/impl/test_fs.py
+++ b/src/unittest/python/fman_unittest/impl/test_fs.py
@@ -1,0 +1,47 @@
+from fman.fs import FileSystem
+from threading import Thread, Barrier, Lock
+from unittest import TestCase
+
+class NotifyFileChangedTest(TestCase):
+	def test_callback_called(self):
+		fs = FileSystem()
+		results = []
+		fs._file_changed_callbacks['test'] = [lambda url: results.append(url)]
+		fs.notify_file_changed('test')
+		self.assertEqual([fs.scheme + 'test'], results)
+	def test_no_callbacks_for_path(self):
+		fs = FileSystem()
+		fs.notify_file_changed('nonexistent')
+	def test_callback_removal_during_notify(self):
+		fs = FileSystem()
+		results = []
+		callbacks = []
+		def remove_self(url):
+			with fs._file_changed_callbacks_lock:
+				callbacks.remove(remove_self)
+			results.append('removed')
+		def second(url):
+			results.append('second')
+		callbacks.extend([remove_self, second])
+		fs._file_changed_callbacks['test'] = callbacks
+		fs.notify_file_changed('test')
+		self.assertEqual(['removed', 'second'], results)
+	def test_thread_safety(self):
+		fs = FileSystem()
+		call_count = 0
+		count_lock = Lock()
+		def counter(url):
+			nonlocal call_count
+			with count_lock:
+				call_count += 1
+		fs._file_changed_callbacks['test'] = [counter]
+		barrier = Barrier(10)
+		def notify():
+			barrier.wait()
+			fs.notify_file_changed('test')
+		threads = [Thread(target=notify) for _ in range(10)]
+		for t in threads:
+			t.start()
+		for t in threads:
+			t.join()
+		self.assertEqual(10, call_count)

--- a/src/unittest/python/fman_unittest/impl/test_widgets.py
+++ b/src/unittest/python/fman_unittest/impl/test_widgets.py
@@ -1,0 +1,33 @@
+from unittest import TestCase
+
+import struct
+
+class SaveRestoreStateTest(TestCase):
+	def test_roundtrip_small_state(self):
+		self_state = b'\x01\x02\x03'
+		splitter_state = b'\x04\x05'
+		combined = self_state + splitter_state + struct.pack('<I', len(self_state))
+		self_state_len = struct.unpack('<I', combined[-4:])[0]
+		self.assertEqual(3, self_state_len)
+		self.assertEqual(self_state, combined[0:self_state_len])
+		self.assertEqual(splitter_state, combined[self_state_len:-4])
+	def test_roundtrip_large_state(self):
+		self_state = bytes(range(256)) * 4
+		splitter_state = b'\xff' * 100
+		combined = self_state + splitter_state + struct.pack('<I', len(self_state))
+		self_state_len = struct.unpack('<I', combined[-4:])[0]
+		self.assertEqual(1024, self_state_len)
+		self.assertEqual(self_state, combined[0:self_state_len])
+		self.assertEqual(splitter_state, combined[self_state_len:-4])
+	def test_state_over_255_bytes(self):
+		self_state = b'\xab' * 300
+		packed = struct.pack('<I', len(self_state))
+		self.assertEqual(4, len(packed))
+		self.assertEqual(300, struct.unpack('<I', packed)[0])
+	def test_empty_splitter_state(self):
+		self_state = b'\x01\x02'
+		splitter_state = b''
+		combined = self_state + splitter_state + struct.pack('<I', len(self_state))
+		self_state_len = struct.unpack('<I', combined[-4:])[0]
+		self.assertEqual(self_state, combined[0:self_state_len])
+		self.assertEqual(b'', combined[self_state_len:-4])

--- a/src/unittest/python/fman_unittest/impl/view/test_resize_cols_to_contents.py
+++ b/src/unittest/python/fman_unittest/impl/view/test_resize_cols_to_contents.py
@@ -43,6 +43,12 @@ class ResizeColumnTest(TestCase):
 		self._expect([2, 1], 0, 2, [1, 2], [1, 1], 3)
 	def test_rightalign_last_col(self):
 		self._expect([1, 2, 1], 0, 1, [2, 1, 1], [1, 1, 1])
+	def test_shrink_respects_available_width_cap(self):
+		result = _resize_column(0, 3, [3, 1, 1], [1, 1, 1], 6)
+		self.assertLessEqual(sum(result), 6)
+	def test_shrink_expansion_does_not_exceed_available(self):
+		result = _resize_column(0, 4, [4, 1], [1, 1], 5)
+		self.assertLessEqual(sum(result), 5)
 	def _expect(
 		self, result, col, old_size, widths, min_widths, available_width=None
 	):


### PR DESCRIPTION
Initally after trying out the fman build on python 3.14 I have encountered a lot of errors, crashes and incompatibilities with existing (installed) plugins I have been using with 1.7.3 version. To enable them it took a few iterations over the entire code until I was satisfied with the performance and backward compatibility. I will provide a series of stacked PRs   containing bugfixes, adaptations and test suites increasing the overall coverage as much as it was possible. 

Not expecting these to be merged, just flagging things I noticed. If any changes look useful, I'm available to help adapt the code or fix bugs as needed.

- zip.py: early return inside loop broke attribute lookup for non-first entries
- widgets.py: saveState/restoreState crashed when QMainWindow state >= 256 bytes (bytes→struct.pack)
- drag_and_drop.py: unguarded from_qurl in dropMimeData caused crash on invalid URLs
- commands/__init__.py: tuple-unpack crash when zip has != 1 top-level directory
- fs.py: notify_file_changed race on callback list (added lock + snapshot)
- util/__init__.py: Event.trigger mutation during iteration (snapshot copy)
- model.py: sort() mutated shared state from worker thread (atomic commit via main thread)
- model.py: _load_remaining_files iterated self._rows without snapshot
- mother_fs.py: CachedIterator remove→append race made files permanently invisible
- mother_fs.py: CachedIterator.get_next held lock during blocking I/O
- model.py: reload() cleared iterdir cache but not per-file stat cache
- commands/__init__.py: HistoryListener KeyError on GoBack/GoForward
- plugin.py: break after first validation error silently dropped subsequent errors
- commands/__init__.py: wrong show_alert() variant in _Delete task
- model/__init__.py: SortedFileSystemModel memory leak (added shutdown + visited cap)
- resize_cols_to_contents.py: column expansion on shrink ignored available_width
- goto.py: dead dedup code (already_yielded set populated but never checked)
- fman/__init__.py: removed 3 stale TODO comments
- install.txt: fixed timestamp URL + removed hardcoded personal path
- arch.txt: added comment explaining intentional pgi absence
- build.py: publish() missing Debian branch
- ubuntu.py: hardcoded x86_64 libgtk path → ctypes.util.find_library
- mac.py: migrated xcrun altool → notarytool submit --wait
- build_impl/__init__.py: is_package regex → hasattr(__path__)
- command_registry.py: after_command fired even when command raised exception
- commands/__init__.py: removed dead variable
- windows.txt: removed duplicate PyQt5 pin
- fedora/fman.repo: enabled gpgcheck + added gpgkey
- desk.cmd: hardcoded path → relative %~dp0..
- post-commit: hardcoded secret → env var
- CHANGELOG.md: added QtQmlModels to stripped frameworks list
- build_impl/__init__.py: master → main branch reference
- added tests to cover these changes