### PR TITLE
Codebase improvements 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ __pycache__/
 *.py[cod]
 cache/
 venv/
+.venv/
 target/
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,5 +36,5 @@
   `try/except TypeError` around `Path.resolve(strict=True)` and updated
   version-specific comments.
 - **Reduced macOS app bundle size** from ~110MB to ~77MB by stripping unused
-  Qt frameworks (QtQml, QtQuick, QtWebSockets), unused Qt plugins, and
+  Qt frameworks (QtQml, QtQmlModels, QtQuick, QtWebSockets), unused Qt plugins, and
   build-only dependencies (boto3/botocore) from the frozen bundle.

--- a/bin/desk.cmd
+++ b/bin/desk.cmd
@@ -3,11 +3,13 @@ set PATH=C:\Windows\SysWOW64\downlevel;C:\Program Files (x86)\NSIS;C:\Program Fi
 SET ROOT=%~dp0..
 CD %ROOT%
 
-CALL venv\scripts\activate.bat
+CALL .venv\scripts\activate.bat
 DOSKEY run=python build.py run $*
 DOSKEY clean=python build.py clean
 DOSKEY freeze=python build.py freeze $*
 DOSKEY installer=python build.py installer $*
+DOSKEY sign=python build.py sign $*
 DOSKEY sign_installer=python build.py sign_installer $*
+DOSKEY publish=python build.py publish $*
 DOSKEY tests=python build.py test $*
 DOSKEY release=python build.py release $*

--- a/bin/desk.cmd
+++ b/bin/desk.cmd
@@ -1,6 +1,6 @@
 set PATH=C:\Windows\SysWOW64\downlevel;C:\Program Files (x86)\NSIS;C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x86;%PATH%
 
-SET ROOT=c:\Users\micha\dev\fman
+SET ROOT=%~dp0..
 CD %ROOT%
 
 CALL venv\scripts\activate.bat

--- a/bin/desk.cmd
+++ b/bin/desk.cmd
@@ -1,4 +1,9 @@
-set PATH=C:\Windows\SysWOW64\downlevel;C:\Program Files (x86)\NSIS;C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x86;%PATH%
+FOR /F "delims=" %%i IN ('dir /b /ad /o-n "C:\Program Files (x86)\Windows Kits\10\bin\10.*"') DO (
+    SET "WIN_SDK_VER=%%i"
+    GOTO :sdk_found
+)
+:sdk_found
+set PATH=C:\Windows\SysWOW64\downlevel;C:\Program Files (x86)\NSIS;C:\Program Files (x86)\Windows Kits\10\bin\%WIN_SDK_VER%\x86;%PATH%
 
 SET ROOT=%~dp0..
 CD %ROOT%

--- a/bin/desk.sh
+++ b/bin/desk.sh
@@ -26,7 +26,7 @@ THIS_SCRIPT_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 PROJECT_DIR="$THIS_SCRIPT_DIR/.."
 
 cd "$PROJECT_DIR"
-source venv/bin/activate
+source .venv/bin/activate
 
 PS1="(fman) \h:\W \u\$ "
 

--- a/bin/post-commit
+++ b/bin/post-commit
@@ -9,7 +9,7 @@ message_tmp_file=`mktemp`
 git log --pretty=format:%B -n1 > ${message_tmp_file}
 sha=`git log --pretty=format:%H -n1`
 date=`git log --pretty=format:%cd --date=iso-strict -n1`
-curl --data-urlencode secret=k92XhhhmOf8rD7QJ --data-urlencode sha=${sha} \
+curl --data-urlencode secret=${FMAN_API_SECRET} --data-urlencode sha=${sha} \
 	--data-urlencode date=${date} --data-urlencode message@${message_tmp_file} \
 	${URL}
 rm ${message_tmp_file}

--- a/bin/post-commit
+++ b/bin/post-commit
@@ -5,11 +5,15 @@ set -e
 
 URL=https://fman.io/api/record-commit/
 
+if [ -z "${FMAN_API_SECRET:-}" ]; then
+	exit 0
+fi
+
 message_tmp_file=`mktemp`
 git log --pretty=format:%B -n1 > ${message_tmp_file}
 sha=`git log --pretty=format:%H -n1`
 date=`git log --pretty=format:%cd --date=iso-strict -n1`
-curl --data-urlencode secret=${FMAN_API_SECRET} --data-urlencode sha=${sha} \
+curl --fail --silent --data-urlencode secret=${FMAN_API_SECRET} --data-urlencode sha=${sha} \
 	--data-urlencode date=${date} --data-urlencode message@${message_tmp_file} \
 	${URL}
 rm ${message_tmp_file}

--- a/build.py
+++ b/build.py
@@ -135,7 +135,8 @@ snapshot_suffix = '-SNAPSHOT'
 def post_release():
 	activate_profile('release')
 	version = SETTINGS['version']
-	assert not version.endswith(snapshot_suffix)
+	if version.endswith(snapshot_suffix):
+		raise ValueError('Cannot post_release a SNAPSHOT version: %s' % version)
 	cloudfront_items_to_invalidate = []
 	for item in ('fman.dmg', 'fman.deb', 'fman.pkg.tar.xz', 'fman.rpm'):
 		cloudfront_items_to_invalidate.append(item)

--- a/build.py
+++ b/build.py
@@ -49,7 +49,7 @@ def publish():
 		sign_installer()
 		upload()
 	elif is_linux():
-		if is_ubuntu():
+		if is_ubuntu() or linux_distribution() == 'Debian GNU/Linux':
 			freeze()
 			installer()
 			upload()

--- a/build.py
+++ b/build.py
@@ -96,7 +96,7 @@ def release():
 					settings_path, next_version + snapshot_suffix,
 					'Bump version for next development iteration'
 				)
-				git('push', '-u', 'origin', 'master')
+				git('push', '-u', 'origin', 'main')
 				try:
 					git('push', 'origin', release_tag)
 					try:
@@ -106,7 +106,7 @@ def release():
 							'    git pull\n'
 							'    git checkout %s\n'
 							'    python build.py release\n'
-							'    git checkout master\n\n'
+							'    git checkout main\n\n'
 							'on the other OSs now, then come back here and do:'
 							'\n\n'
 							'    python build.py post_release\n'
@@ -117,7 +117,7 @@ def release():
 						raise
 				except:
 					git('revert', '--no-edit', revision_before + '..HEAD' )
-					git('push', '-u', 'origin', 'master')
+					git('push', '-u', 'origin', 'main')
 					revision_before = git('rev-parse', 'HEAD').rstrip()
 					raise
 			except:
@@ -149,7 +149,7 @@ def post_release():
 	create_cloudfront_invalidation(cloudfront_items_to_invalidate)
 	record_release_on_server()
 	upload_core_to_github()
-	git('checkout', 'master')
+	git('checkout', 'main')
 
 def _prompt_for_next_version(release_version):
 	next_version = _get_suggested_next_version(release_version)

--- a/build.py
+++ b/build.py
@@ -10,7 +10,6 @@ from fbs.builtin_commands import clean
 from fbs.cmdline import command
 from fbs_runtime.platform import is_windows, is_mac, is_linux, is_ubuntu, \
 	is_fedora, is_arch_linux, linux_distribution
-from os.path import dirname
 
 import fbs.cmdline
 import re
@@ -112,18 +111,18 @@ def release():
 							'    python build.py post_release\n'
 							% release_tag
 						)
-					except:
+					except Exception:
 						git('push', '--delete', 'origin', release_tag)
 						raise
-				except:
+				except Exception:
 					git('revert', '--no-edit', revision_before + '..HEAD' )
 					git('push', '-u', 'origin', 'main')
 					revision_before = git('rev-parse', 'HEAD').rstrip()
 					raise
-			except:
+			except Exception:
 				git('tag', '-d', release_tag)
 				raise
-		except:
+		except Exception:
 			git('reset', revision_before)
 			_replace_in_json(settings_path, 'version', version)
 			raise

--- a/install.txt
+++ b/install.txt
@@ -30,10 +30,10 @@ fmanSetup.exe (Google Omaha installer)
 ======================================
 1)
 hammer -c
-set TIMESTAMP_SERVER=http://sha256timestamp.ws.symantec.com/sha256/timestamp
+set TIMESTAMP_SERVER=http://timestamp.digicert.com
 set SHA1_TIMESTAMP_SERVER=%TIMESTAMP_SERVER%
 set SHA2_TIMESTAMP_SERVER=%TIMESTAMP_SERVER%
-set AUTHENTICODE_FILE="c:\Users\Michael\dev\fman\conf\windows\michaelherrmann.pfx"
+set AUTHENTICODE_FILE="<path-to-your-pfx-certificate>"
 set AUTHENTICODE_PASSWORD="..."
 hammer MODE=opt-win --authenticode_file=%AUTHENTICODE_FILE% --authenticode_password=%AUTHENTICODE_PASSWORD% --sha1_authenticode_file=%AUTHENTICODE_FILE% --sha2_authenticode_file=%AUTHENTICODE_FILE% --sha1_authenticode_password=%AUTHENTICODE_PASSWORD% --sha2_authenticode_password=%AUTHENTICODE_PASSWORD%
 

--- a/install.txt
+++ b/install.txt
@@ -14,7 +14,7 @@ with the GUI.
 
 NSIS:
 =====
-Install version 2.51 on Windows.
+Install NSIS 3.x on Windows.
 Add to PATH.
 
 Linux (Ubuntu) extra

--- a/install.txt
+++ b/install.txt
@@ -7,7 +7,7 @@ Import developer certificate:
     security import "~/dev/fman/conf/mac/Private key.p12" -k ~/Library/Keychains/login.keychain -P "" -T /usr/bin/codesign
 
 Install a version of XCode that is compatible with your macOS version from
-https://developer.apple.com/download/more/?q=xcode.
+https://developer.apple.com/download/all/?q=xcode.
 
 Code signing usually does not work when invoked via SSH. It prompts for a pw
 with the GUI.

--- a/requirements/arch.txt
+++ b/requirements/arch.txt
@@ -1,1 +1,3 @@
+# pgi intentionally excluded — Gnome icon integration unavailable on Arch.
+# Qt's default QFileIconProvider is used instead.
 -r linux.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-fbs[sentry] @ http://build-system.fman.io/pro/b5aab865-bd29-4f23-992c-0eb4f3a24f33/0.9.4
+fbs[sentry] @ https://build-system.fman.io/pro/b5aab865-bd29-4f23-992c-0eb4f3a24f33/0.9.4
 PyQt5==5.15.11
 PyInstaller==6.19.0
 rsa==4.9

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -1,5 +1,4 @@
 -r base.txt
-PyQt5==5.15.11
 # Note: Send2Trash 1.5.0 has no effect on Windows!
 Send2Trash==1.8.3
 adodbapi==2.6.0.7

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -1,5 +1,4 @@
 -r base.txt
-# Note: Send2Trash 1.5.0 has no effect on Windows!
 Send2Trash==1.8.3
 adodbapi==2.6.0.7
 pywinpty==2.0.14

--- a/src/build/docker/arch/Dockerfile
+++ b/src/build/docker/arch/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /root/${app_name}
 
 # Set up virtual environment:
 ADD *.txt /tmp/requirements/
-RUN python -m venv venv && \
-    venv/bin/python -m pip install -U pip && \
-    venv/bin/python -m pip install -r "/tmp/requirements/${requirements}"
+RUN python -m venv .venv && \
+    .venv/bin/python -m pip install -U pip && \
+    .venv/bin/python -m pip install -r "/tmp/requirements/${requirements}"
 RUN rm -rf /tmp/requirements/
 
 ADD .bashrc /root/.bashrc

--- a/src/build/docker/fedora/Dockerfile
+++ b/src/build/docker/fedora/Dockerfile
@@ -20,9 +20,9 @@ RUN dnf install -y gobject-introspection
 
 # Set up virtual environment:
 ADD *.txt /tmp/requirements/
-RUN python3.9 -m venv venv && \
-    venv/bin/python -m pip install -U pip && \
-    venv/bin/python -m pip install -r "/tmp/requirements/${requirements}"
+RUN python3.9 -m venv .venv && \
+    .venv/bin/python -m pip install -U pip && \
+    .venv/bin/python -m pip install -r "/tmp/requirements/${requirements}"
 RUN rm -rf /tmp/requirements/
 
 ADD .bashrc /root

--- a/src/build/docker/ubuntu/Dockerfile
+++ b/src/build/docker/ubuntu/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get install libgl1-mesa-glx -y
 
 # fpm:
 RUN apt-get install ruby ruby-dev build-essential -y && \
-    gem install --no-ri --no-rdoc fpm
+    gem install --no-document fpm
 
 WORKDIR /root/${app_name}
 

--- a/src/build/docker/ubuntu/Dockerfile
+++ b/src/build/docker/ubuntu/Dockerfile
@@ -25,9 +25,9 @@ RUN apt-get install gobject-introspection libgtk-3-0 -y
 
 # Set up virtual environment:
 ADD *.txt /tmp/requirements/
-RUN python3.9 -m venv venv && \
-    venv/bin/python -m pip install -U pip && \
-    venv/bin/python -m pip install -r "/tmp/requirements/${requirements}"
+RUN python3.9 -m venv .venv && \
+    .venv/bin/python -m pip install -U pip && \
+    .venv/bin/python -m pip install -r "/tmp/requirements/${requirements}"
 RUN rm -rf /tmp/requirements/
 
 ADD .bashrc /root/.bashrc

--- a/src/build/python/build_impl/__init__.py
+++ b/src/build/python/build_impl/__init__.py
@@ -79,7 +79,7 @@ def run_on_server(command):
 		return check_output_decode(command, shell=True)
 
 def check_output_decode(*args, **kwargs):
-	return check_output(*args, **kwargs).decode(sys.stdout.encoding)
+	return check_output(*args, **kwargs).decode(sys.stdout.encoding or 'utf-8')
 
 def upload_installer_to_aws(installer_name):
 	assert SETTINGS['release']

--- a/src/build/python/build_impl/__init__.py
+++ b/src/build/python/build_impl/__init__.py
@@ -82,7 +82,8 @@ def check_output_decode(*args, **kwargs):
 	return check_output(*args, **kwargs).decode(sys.stdout.encoding or 'utf-8')
 
 def upload_installer_to_aws(installer_name):
-	assert SETTINGS['release']
+	if not SETTINGS['release']:
+		raise RuntimeError('upload_installer_to_aws called in non-release mode')
 	src_path = path('target/' + installer_name)
 	upload_to_s3(src_path, installer_name)
 	version_dest_path = '%s/%s' % (SETTINGS['version'], installer_name)
@@ -118,7 +119,7 @@ def upload_core_to_github():
 					if not line.startswith('#') and line.rstrip()
 				}
 			for name in listdir(tmp_dir):
-				if name not in extra_files:
+				if name not in extra_files and name != '.git':
 					if isdir(name):
 						rmtree(name)
 					else:
@@ -146,8 +147,11 @@ def upload_core_to_github():
 
 def record_release_on_server():
 	import requests
-	response = requests.post(SETTINGS['record_release_url'], {
+	url = SETTINGS['record_release_url']
+	if not url.startswith('https://'):
+		raise ValueError('record_release_url must use HTTPS')
+	response = requests.post(url, {
 		'secret': SETTINGS['server_api_secret'],
 		'version': SETTINGS['version']
-	})
+	}, timeout=30)
 	response.raise_for_status()

--- a/src/build/python/build_impl/__init__.py
+++ b/src/build/python/build_impl/__init__.py
@@ -25,7 +25,7 @@ def remove_if_exists(file_path):
 
 def copy_python_library(name, dest_dir):
 	library = import_module(name)
-	is_package = re.match(r'^__init__\.pyc?$', basename(library.__file__))
+	is_package = hasattr(library, '__path__')
 	if is_package:
 		package_dir = dirname(library.__file__)
 		copytree(package_dir, join(dest_dir, basename(package_dir)))
@@ -137,7 +137,7 @@ def upload_core_to_github():
 					'commit', '-m',
 					'Source code of the Core plugin in fman ' + version
 				)
-				git('push', '-u', 'origin', 'master', ssh_key=ssh_key)
+				git('push', '-u', 'origin', 'main', ssh_key=ssh_key)
 			tag = 'v' + version
 			git('tag', tag)
 			git('push', 'origin', tag, ssh_key=ssh_key)

--- a/src/build/python/build_impl/__init__.py
+++ b/src/build/python/build_impl/__init__.py
@@ -54,7 +54,7 @@ def upload_file(f, dest_dir, dest_name=None):
 		run(args, check=True)
 	else:
 		if isdir(f):
-			copytree(f, join(dest_dir, dest_name or basename(f)))
+			copytree(f, join(dest_path, dest_name or basename(f)))
 		else:
 			copy(f, dest_path)
 
@@ -105,7 +105,7 @@ def upload_core_to_github():
 	ssh_key = path('${core_plugin_ssh_key}')
 	if not is_windows():
 		# Prevent clone failing due to lacking access restrictions:
-		run(['chmod', '600', ssh_key])
+		run(['chmod', '600', ssh_key], check=True)
 	with TemporaryDirectory() as tmp_dir:
 		cwd_before = getcwd()
 		chdir(tmp_dir)

--- a/src/build/python/build_impl/aws.py
+++ b/src/build/python/build_impl/aws.py
@@ -44,7 +44,7 @@ def create_cloudfront_invalidation(items):
 				'Quantity': len(items),
 				'Items': ['/' + item for item in items]
 			},
-			'CallerReference': str(int(time()))
+			'CallerReference': '%s-%s' % (int(time()), id(items))
 		}
 	)
 

--- a/src/build/python/build_impl/mac.py
+++ b/src/build/python/build_impl/mac.py
@@ -7,13 +7,9 @@ from glob import glob
 from os import remove
 from os.path import basename, join
 from shutil import rmtree, move
-from subprocess import run, PIPE, CalledProcessError, SubprocessError
-from time import sleep
+from subprocess import run, PIPE
 
-import json
 import os
-import plistlib
-import requests
 
 _UPDATES_DIR = 'updates/mac'
 
@@ -114,44 +110,25 @@ def _run_codesign(*args):
 def _staple(file_path):
 	run(['xcrun', 'stapler', 'staple', file_path], check=True)
 
-def _notarize(file_path, query_interval_secs=10):
-	response = _run_altool([
-		'--notarize-app', '-t', 'osx', '-f', file_path,
-		'--primary-bundle-id', SETTINGS['mac_bundle_identifier']
-	])
-	request_uuid = response['notarization-upload']['RequestUUID']
-	while True:
-		sleep(query_interval_secs)
-		try:
-			response = _run_altool(['--notarization-info', request_uuid])
-		except CalledProcessError as e:
-			stdout = e.stdout.decode('utf-8')
-			if 'Could not find the RequestUUID' not in stdout:
-				raise
-		else:
-			status = response['notarization-info']['Status']
-			if status != 'in progress':
-				break
-		print('Waiting for notarization to complete...')
-	log_url = response['notarization-info']['LogFileURL']
-	log_response = requests.get(log_url)
-	log_response.raise_for_status()
-	log_json = log_response.json()
-	issues = log_json.get('issues', [])
-	if issues:
-		print('Notarization encountered some issues:')
-		print(json.dumps(issues, indent=4, sort_keys=True))
-	if status != 'success':
-		raise RuntimeError('Unexpected notarization status: %r' % status)
-
-def _run_altool(args):
-	all_args = [
-		'xcrun', 'altool', '--output-format', 'xml',
-		'-u', SETTINGS['apple_developer_user'],
-		'-p', SETTINGS['apple_developer_app_pw']
-	] + args
-	process = run(all_args, stdout=PIPE, stderr=PIPE, check=True)
-	return plistlib.loads(process.stdout)
+def _notarize(file_path):
+	result = run(
+		[
+			'xcrun', 'notarytool', 'submit', file_path, '--wait',
+			'--apple-id', SETTINGS['apple_developer_user'],
+			'--password', SETTINGS['apple_developer_app_pw'],
+			'--team-id', SETTINGS['apple_developer_team_id']
+		],
+		stdout=PIPE, stderr=PIPE, check=False
+	)
+	output = result.stdout.decode('utf-8')
+	print(output)
+	if result.returncode != 0:
+		stderr = result.stderr.decode('utf-8')
+		raise RuntimeError(
+			'Notarization failed (exit %d):\n%s' % (result.returncode, stderr)
+		)
+	if 'status: Accepted' not in output:
+		raise RuntimeError('Unexpected notarization status:\n%s' % output)
 
 @command
 def sign_installer():

--- a/src/build/python/build_impl/ubuntu.py
+++ b/src/build/python/build_impl/ubuntu.py
@@ -42,12 +42,7 @@ def _remove_gtk_dependencies():
 			raise ValueError(repr(line))
 		so_name, so_path = match.groups()
 		if so_name and so_path:
-			# libQt5Widgets.so.0 depends on libpng12.so.0. This file is present
-			# on Ubuntu versions < 17.04. On 17.04 (and above?), libpng16.so.0
-			# is used instead. We therefore need to keep libpng12.so.0 so fman
-			# can run on Ubuntu 17.04+:
-			if so_name != 'libpng12.so.0':
-				remove_if_exists(path('${freeze_dir}/' + so_name))
+			remove_if_exists(path('${freeze_dir}/' + so_name))
 
 @command
 def upload():

--- a/src/build/python/build_impl/ubuntu.py
+++ b/src/build/python/build_impl/ubuntu.py
@@ -26,8 +26,12 @@ def freeze():
 	_remove_gtk_dependencies()
 
 def _remove_gtk_dependencies():
+	import ctypes.util
+	gtk_path = ctypes.util.find_library('gtk-3')
+	if gtk_path is None:
+		return
 	output = check_output_decode(
-		'ldd /usr/lib/x86_64-linux-gnu/libgtk-3.so.0', shell=True
+		'ldd ' + gtk_path, shell=True
 	)
 	assert output.endswith('\n')
 	for line in output.split('\n')[:-1]:

--- a/src/build/settings/fedora.json
+++ b/src/build/settings/fedora.json
@@ -1,3 +1,4 @@
 {
+	"hidden_imports": ["pgi.overrides.GObject", "pgi.overrides.GLib"],
 	"gpg_preset_passphrase": "/usr/libexec/gpg-preset-passphrase"
 }

--- a/src/build/settings/mac.json
+++ b/src/build/settings/mac.json
@@ -9,5 +9,6 @@
 		"src/freeze/mac/Contents/SharedSupport/bin/fman"
 	],
 	"apple_developer_user": "michael@herrmann.io",
-	"apple_developer_app_pw": "apsy-xzlg-dszl-kttf"
+	"apple_developer_app_pw": "apsy-xzlg-dszl-kttf",
+	"apple_developer_team_id": ""
 }

--- a/src/build/settings/windows.json
+++ b/src/build/settings/windows.json
@@ -4,5 +4,5 @@
 		"win32com.shell.shellcon", "win32gui", "winpty", "win32wnet"
 	],
 	"windows_sign_pass": "Tu4suttmdpn",
-	"windows_sign_server": "http://sha256timestamp.ws.symantec.com/sha256/timestamp"
+	"windows_sign_server": "http://timestamp.digicert.com"
 }

--- a/src/main/python/fman/__init__.py
+++ b/src/main/python/fman/__init__.py
@@ -36,7 +36,10 @@ FMAN_VERSION = ''
 PLATFORM = platform.name()
 
 if PLATFORM == 'Windows':
-	DATA_DIRECTORY = join(getenv('APPDATA'), 'fman')
+	_appdata = getenv('APPDATA')
+	if not _appdata:
+		raise RuntimeError('APPDATA environment variable is not set')
+	DATA_DIRECTORY = join(_appdata, 'fman')
 elif PLATFORM == 'Mac':
 	DATA_DIRECTORY = expanduser('~/Library/Application Support/fman')
 elif PLATFORM == 'Linux':

--- a/src/main/python/fman/__init__.py
+++ b/src/main/python/fman/__init__.py
@@ -41,6 +41,8 @@ elif PLATFORM == 'Mac':
 	DATA_DIRECTORY = expanduser('~/Library/Application Support/fman')
 elif PLATFORM == 'Linux':
 	DATA_DIRECTORY = expanduser('~/.config/fman')
+else:
+	raise NotImplementedError('Unsupported platform: %s' % PLATFORM)
 
 class ApplicationCommand:
 	def __init__(self, window):

--- a/src/main/python/fman/__init__.py
+++ b/src/main/python/fman/__init__.py
@@ -70,7 +70,7 @@ class DirectoryPane:
 	def _add_listener(self, listener):
 		self._listeners.append(listener)
 	def _broadcast(self, event, *args):
-		for listener in self._listeners:
+		for listener in list(self._listeners):
 			getattr(listener, event)(*args)
 
 	def get_commands(self):
@@ -79,7 +79,7 @@ class DirectoryPane:
 		if args is None:
 			args = {}
 		while True:
-			for listener in self._listeners:
+			for listener in list(self._listeners):
 				rewritten = listener.on_command(name, args)
 				if rewritten:
 					name, args = rewritten
@@ -120,7 +120,7 @@ class DirectoryPane:
 	def set_path(self, dir_url, callback=None, onerror=_set_path_onerror):
 		args = dir_url, '', True
 		while True:
-			for listener in self._listeners:
+			for listener in list(self._listeners):
 				rewritten = listener.before_location_change(*args)
 				if rewritten and rewritten != args:
 					args = rewritten
@@ -200,6 +200,7 @@ class DirectoryPaneListener:
 	def on_path_changed(self):
 		pass
 	def before_location_change(self, url, sort_column='', ascending=True):
+		"""Return (url, sort_column, ascending) to rewrite, or None to allow."""
 		pass
 	def on_files_dropped(self, file_urls, dest_dir, is_copy_not_move):
 		pass

--- a/src/main/python/fman/__init__.py
+++ b/src/main/python/fman/__init__.py
@@ -115,10 +115,8 @@ class DirectoryPane:
 		self._widget.move_cursor_page_up(toggle_selection)
 	def place_cursor_at(self, file_url):
 		self._widget.place_cursor_at(file_url)
-	# TODO: Rename to get_location()
 	def get_path(self):
 		return self._widget.get_location()
-	# TODO: Rename to set_location(...)
 	def set_path(self, dir_url, callback=None, onerror=_set_path_onerror):
 		args = dir_url, '', True
 		while True:
@@ -199,7 +197,6 @@ class DirectoryPaneListener:
 		pass
 	def on_name_edited(self, file_url, new_name):
 		pass
-	# TODO: Rename to after_location_change()
 	def on_path_changed(self):
 		pass
 	def before_location_change(self, url, sort_column='', ascending=True):

--- a/src/main/python/fman/fs.py
+++ b/src/main/python/fman/fs.py
@@ -67,6 +67,9 @@ def notify_file_removed(url):
 	_get_mother_fs().notify_file_removed(url)
 
 class FileSystem:
+	"""Base class for file system plugins. Set scheme to eg. 'ftp://'.
+	Methods receive scheme-stripped paths, except copy/move which get full URLs.
+	"""
 
 	scheme = ''
 
@@ -153,6 +156,7 @@ class FileSystem:
 	def touch(self, path):
 		raise self._operation_not_implemented()
 	def copy(self, src_url, dst_url):
+		"""Unlike other methods, receives full URLs (with scheme), not paths."""
 		raise self._operation_not_implemented()
 	def prepare_copy(self, src_url, dst_url):
 		if self.copy.__func__ is FileSystem.copy:
@@ -163,6 +167,7 @@ class FileSystem:
 			fn=self.copy, args=(src_url, dst_url)
 		)]
 	def move(self, src_url, dst_url):
+		"""Unlike other methods, receives full URLs (with scheme), not paths."""
 		raise self._operation_not_implemented()
 	def prepare_move(self, src_url, dst_url):
 		if self.move.__func__ is FileSystem.move:

--- a/src/main/python/fman/fs.py
+++ b/src/main/python/fman/fs.py
@@ -108,7 +108,9 @@ class FileSystem:
 	def notify_file_removed(self, path):
 		self._file_removed.trigger(self.scheme + path)
 	def notify_file_changed(self, path):
-		for callback in self._file_changed_callbacks.get(path, []):
+		with self._file_changed_callbacks_lock:
+			callbacks = list(self._file_changed_callbacks.get(path, []))
+		for callback in callbacks:
 			callback(self.scheme + path)
 	def samefile(self, path1, path2):
 		return self.resolve(path1) == self.resolve(path2)

--- a/src/main/python/fman/fs.py
+++ b/src/main/python/fman/fs.py
@@ -146,7 +146,7 @@ class FileSystem:
 			raise self._operation_not_implemented()
 		return [Task(
 			'Deleting ' + path.rsplit('/', 1)[-1],
-			fn=self.delete, args=(path,), size=1
+			fn=self.move_to_trash, args=(path,), size=1
 		)]
 	def touch(self, path):
 		raise self._operation_not_implemented()

--- a/src/main/python/fman/impl/application_context.py
+++ b/src/main/python/fman/impl/application_context.py
@@ -431,29 +431,11 @@ class FrozenApplicationContext(DevelopmentApplicationContext):
 		logging.basicConfig(level=logging.CRITICAL)
 	def on_main_window_shown(self):
 		if PLATFORM == 'Linux':
-			"""
-			PyInstaller sets LD_LIBRARY_PATH to /opt/fman. Processes we spawn,
-			be it via Popen(...) or QDesktopServices.openUrl(...), inherit this
-			value. This leads to problems, especially when the app we launch is
-			based on Qt. The reason is that the OS then attempts to load our 
-			libraries, which are most likely incompatible with those of the app.
-			An example where this happens is VLC, which errors out with 'This 
-			application failed to start because it could not find or load the Qt
-			platform plugin "xcb"'. Plugin developers have also encountered this
-			unexpected behaviour when trying to launch apps.
-			
-			To fix the problem, we restore LD_LIBRARY_PATH to its original value
-			here. According to the docs [1], PyInstaller stores this value in a
-			separate environment variable.
-			
-			A drawback of unsetting the environment variable here is that
-			libraries from PyInstaller's search path cannot be loaded after this
-			method was called. In other words, we assume that all required
-			libraries have been loaded once we reach here. This assumption may
-			turn out to be wrong in the future.
-			
-			[1]: http://pyinstaller.readthedocs.io/en/stable/runtime-information.html#ld-library-path-libpath-considerations
-			"""
+			# PyInstaller sets LD_LIBRARY_PATH to /opt/fman. Processes we spawn
+			# inherit this value, causing problems when the launched app is
+			# Qt-based (it tries to load our incompatible libraries).
+			# We restore LD_LIBRARY_PATH to its original value here.
+			# See: https://pyinstaller.org/en/stable/runtime-information.html
 			lp_orig = os.environ.pop('LD_LIBRARY_PATH_ORIG', None)
 			if lp_orig is not None:
 				os.environ['LD_LIBRARY_PATH'] = lp_orig

--- a/src/main/python/fman/impl/controller.py
+++ b/src/main/python/fman/impl/controller.py
@@ -50,12 +50,12 @@ class Controller:
 		pane = self._panes[pane_widget]
 		key_event = QtKeyEvent(qkeyevent.key(), qkeyevent.modifiers())
 		return self._nonexistent_shortcut_handler(key_event, pane)
-	def on_doubleclicked(self, pane_widget, file_path):
+	def on_doubleclicked(self, pane_widget, file_url):
 		past_events = self._metrics.past_events[::]
 		self._metrics.track('DoubleclickedFile')
 		pane = self._panes[pane_widget]
 		if not self._usage_helper.on_doubleclicked(pane, past_events):
-			pane._broadcast('on_doubleclicked', file_path)
+			pane._broadcast('on_doubleclicked', file_url)
 	def on_file_renamed(self, pane_widget, *args):
 		self._metrics.track('RenamedFile')
 		self._panes[pane_widget]._broadcast('on_name_edited', *args)

--- a/src/main/python/fman/impl/fs_cache.py
+++ b/src/main/python/fman/impl/fs_cache.py
@@ -24,18 +24,32 @@ class Cache:
 					self._root.delete_child(path)
 				except KeyError:
 					pass
+	def clear_attr(self, path, attr):
+		with self._lock:
+			try:
+				item = self._root.get_child(path)
+			except KeyError:
+				return
+			item.clear_attr(attr)
 
 class CacheItem:
 	def __init__(self):
 		self._children = {}
 		self._attrs = {}
-		self._attr_locks = defaultdict(RLock)
+		self._attr_locks = {}
+		self._attr_locks_lock = Lock()
 	def put(self, attr, value):
 		self._attrs[attr] = value
 	def get(self, attr):
 		return self._attrs[attr]
+	def clear_attr(self, attr):
+		self._attrs.pop(attr, None)
 	def query(self, attr, compute_value):
-		with self._attr_locks[attr]:
+		with self._attr_locks_lock:
+			if attr not in self._attr_locks:
+				self._attr_locks[attr] = RLock()
+			lock = self._attr_locks[attr]
+		with lock:
 			try:
 				return self._attrs[attr]
 			except KeyError:

--- a/src/main/python/fman/impl/fs_cache.py
+++ b/src/main/python/fman/impl/fs_cache.py
@@ -1,36 +1,40 @@
 from collections import defaultdict
-from threading import Lock
+from threading import Lock, RLock
 
 class Cache:
 	def __init__(self):
+		self._lock = Lock()
 		self._root = CacheItem()
 	def put(self, path, attr, value):
-		self._root.update_child(path).put(attr, value)
+		with self._lock:
+			self._root.update_child(path).put(attr, value)
 	def get(self, path, attr):
-		return self._root.get_child(path).get(attr)
+		with self._lock:
+			return self._root.get_child(path).get(attr)
 	def query(self, path, attr, compute_value):
-		return self._root.update_child(path).query(attr, compute_value)
+		with self._lock:
+			item = self._root.update_child(path)
+		return item.query(attr, compute_value)
 	def clear(self, path):
-		if not path:
-			self._root = CacheItem()
-		else:
-			try:
-				self._root.delete_child(path)
-			except KeyError:
-				pass
+		with self._lock:
+			if not path:
+				self._root = CacheItem()
+			else:
+				try:
+					self._root.delete_child(path)
+				except KeyError:
+					pass
 
 class CacheItem:
 	def __init__(self):
 		self._children = {}
 		self._attrs = {}
-		self._attr_locks = defaultdict(Lock)
+		self._attr_locks = defaultdict(RLock)
 	def put(self, attr, value):
 		self._attrs[attr] = value
 	def get(self, attr):
 		return self._attrs[attr]
 	def query(self, attr, compute_value):
-		# Because `defaultdict` and `Lock` are implemented in C, they do not
-		# release the GIL and the dict access is atomic:
 		with self._attr_locks[attr]:
 			try:
 				return self._attrs[attr]

--- a/src/main/python/fman/impl/model/__init__.py
+++ b/src/main/python/fman/impl/model/__init__.py
@@ -151,6 +151,8 @@ class SortedFileSystemModel(QSortFilterProxyModel):
 	def find(self, url):
 		return self.mapFromSource(self.sourceModel().find(url))
 	def _on_file_removed(self, url):
+		if not self.sourceModel():
+			return
 		if is_pardir(url, self.get_location()):
 			dir_ = dirname(url)
 			if dir_ == url:

--- a/src/main/python/fman/impl/model/__init__.py
+++ b/src/main/python/fman/impl/model/__init__.py
@@ -20,6 +20,8 @@ class SortedFileSystemModel(QSortFilterProxyModel):
 	sort_order_changed = pyqtSignal(int, int)
 	transaction_ended = pyqtSignal()
 
+	_MAX_VISITED = 512
+
 	def __init__(self, parent, fs, null_location):
 		super().__init__(parent)
 		self._fs = fs
@@ -106,6 +108,9 @@ class SortedFileSystemModel(QSortFilterProxyModel):
 		self.setSourceModel(new_model)
 		self._connect_signals(new_model)
 		self._already_visited.add(url)
+		if len(self._already_visited) > self._MAX_VISITED:
+			self._already_visited.clear()
+			self._already_visited.add(url)
 		self.location_changed.emit(url)
 		order = Qt.AscendingOrder if ascending else Qt.DescendingOrder
 		self.sort_order_changed.emit(sort_col_index, order)
@@ -189,5 +194,11 @@ class SortedFileSystemModel(QSortFilterProxyModel):
 		self.sort_order_changed.emit(column, order)
 	def _emit_transaction_ended(self):
 		self.transaction_ended.emit()
+	def shutdown(self):
+		self._fs.file_removed.remove_callback(self._on_file_removed)
+		model = self.sourceModel()
+		if model:
+			self._disconnect_signals(model)
+			model.shutdown()
 	def __str__(self):
 		return '<%s: %s>' % (self.__class__.__name__, self.get_location())

--- a/src/main/python/fman/impl/model/drag_and_drop.py
+++ b/src/main/python/fman/impl/model/drag_and_drop.py
@@ -42,7 +42,7 @@ class DragAndDrop(QAbstractTableModel):
 	def mimeData(self, indexes):
 		result = QMimeData()
 		result.setUrls([as_qurl(self.url(index)) for index in indexes])
-		# The Qt documentation (http://doc.qt.io/qt-5/dnd.html) states that the
+		# The Qt documentation (https://doc.qt.io/archives/qt-5.15/dnd.html) states that the
 		# QMimeData should not be deleted, because the target of the drag and
 		# drop operation takes ownership of it. We must therefore tell SIP not
 		# to garbage-collect `result` once this method returns. Without this

--- a/src/main/python/fman/impl/model/drag_and_drop.py
+++ b/src/main/python/fman/impl/model/drag_and_drop.py
@@ -55,7 +55,14 @@ class DragAndDrop(QAbstractTableModel):
 			return True
 		if not data.hasUrls():
 			return False
-		urls = [from_qurl(qurl) for qurl in data.urls()]
+		urls = []
+		for qurl in data.urls():
+			try:
+				urls.append(from_qurl(qurl))
+			except ValueError:
+				continue
+		if not urls:
+			return False
 		dest = self._get_drop_dest(parent)
 		if action in (MoveAction, CopyAction):
 			self.files_dropped.emit(urls, dest, action == CopyAction)

--- a/src/main/python/fman/impl/model/icon_provider.py
+++ b/src/main/python/fman/impl/model/icon_provider.py
@@ -5,6 +5,7 @@ from pathlib import Path, PurePosixPath
 from PyQt5.QtCore import QFileInfo
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QFileIconProvider
+from threading import Lock
 
 import logging
 import sys
@@ -21,6 +22,7 @@ class IconProvider:
 			f.suffix: self._get_qt_icon(f)
 			for f in Path(cache_dir).glob('file*')
 		}
+		self._cache_lock = Lock()
 	def get_icon(self, url):
 		scheme, path = splitscheme(url)
 		if scheme == 'file://':
@@ -32,14 +34,13 @@ class IconProvider:
 		if self._fs.is_dir(url):
 			return self._folder_icon
 		suffix = PurePosixPath(path).suffix
-		if suffix not in self._cache:
-			surrogate = Path(self._cache_dir, 'file' + suffix)
-			with surrogate.open('w') as f:
-				# At least Gnome doesn't display a proper icon unless the file
-				# has some contents. So give it some:
-				f.write('fman')
-			self._cache[suffix] = self._get_qt_icon(surrogate)
-		return self._cache[suffix]
+		with self._cache_lock:
+			if suffix not in self._cache:
+				surrogate = Path(self._cache_dir, 'file' + suffix)
+				with surrogate.open('w') as f:
+					f.write('fman')
+				self._cache[suffix] = self._get_qt_icon(surrogate)
+			return self._cache[suffix]
 	def _get_qt_icon(self, path):
 		if not isinstance(path, str):
 			path = str(path)

--- a/src/main/python/fman/impl/model/model.py
+++ b/src/main/python/fman/impl/model/model.py
@@ -278,7 +278,7 @@ class Model(SortFilterTableModel, DragAndDrop):
 	@transaction(priority=5)
 	def reload(self):
 		self._fs.clear_cache(self._location)
-		files_snapshot = dict(self._files)
+		files_snapshot = self._files.copy()
 		files = []
 		try:
 			file_names = iter(self._fs.iterdir(self._location))

--- a/src/main/python/fman/impl/model/model.py
+++ b/src/main/python/fman/impl/model/model.py
@@ -215,6 +215,8 @@ class Model(SortFilterTableModel, DragAndDrop):
 		Tells the model that the given `files` exist and the URLs given in
 		`disappeared` do not exist.
 		"""
+		if self._shutdown:
+			return
 		if disappeared is None:
 			disappeared = []
 		self._begin_transaction()
@@ -227,16 +229,18 @@ class Model(SortFilterTableModel, DragAndDrop):
 	def sort(self, column, order=Qt.AscendingOrder):
 		ascending = order == Qt.AscendingOrder
 		updated = {}
-		for i, row in enumerate(list(self._rows)):
+		for row in list(self._rows):
 			if not self._sort_value_is_loaded(row, column, ascending):
 				new_row = self._load_sort_value(row, column, ascending)
-				updated[i] = new_row
+				updated[row.url] = new_row
 		self._commit_sort_updates_and_sort(updated, column, order)
 	@run_in_main_thread
 	def _commit_sort_updates_and_sort(self, updated, column, order):
-		for i, new_row in updated.items():
-			self._rows[i] = new_row
-			self._files[new_row.url] = new_row
+		for i, row in enumerate(self._rows):
+			if row.url in updated:
+				new_row = updated[row.url]
+				self._rows[i] = new_row
+				self._files[new_row.url] = new_row
 		super().sort(column, order)
 	def _sort_value_is_loaded(self, row, column, ascending):
 		try:
@@ -274,6 +278,7 @@ class Model(SortFilterTableModel, DragAndDrop):
 	@transaction(priority=5)
 	def reload(self):
 		self._fs.clear_cache(self._location)
+		files_snapshot = dict(self._files)
 		files = []
 		try:
 			file_names = iter(self._fs.iterdir(self._location))
@@ -293,7 +298,7 @@ class Model(SortFilterTableModel, DragAndDrop):
 				self._fs.clear_cache(url)
 				try:
 					try:
-						file_before = self._files[url]
+						file_before = files_snapshot[url]
 					except KeyError:
 						file_ = self._init_file(url)
 					else:
@@ -312,6 +317,8 @@ class Model(SortFilterTableModel, DragAndDrop):
 		self._load_remaining_files()
 	@run_in_main_thread
 	def _on_files_reloaded(self, rows):
+		if self._shutdown:
+			return
 		self._files = {
 			row.url: row for row in rows
 		}

--- a/src/main/python/fman/impl/model/model.py
+++ b/src/main/python/fman/impl/model/model.py
@@ -226,15 +226,18 @@ class Model(SortFilterTableModel, DragAndDrop):
 	@transaction(priority=3)
 	def sort(self, column, order=Qt.AscendingOrder):
 		ascending = order == Qt.AscendingOrder
-		for i, row in enumerate(self._rows):
+		updated = {}
+		for i, row in enumerate(list(self._rows)):
 			if not self._sort_value_is_loaded(row, column, ascending):
 				new_row = self._load_sort_value(row, column, ascending)
-				# Here, we violate the constraint that data only be changed in
-				# the main thread. But! The data we are changing here is not
-				# "visible" outside this class. So it's OK.
-				self._rows[i] = new_row
-				self._files[row.url] = new_row
-		run_in_main_thread(super().sort)(column, order)
+				updated[i] = new_row
+		self._commit_sort_updates_and_sort(updated, column, order)
+	@run_in_main_thread
+	def _commit_sort_updates_and_sort(self, updated, column, order):
+		for i, new_row in updated.items():
+			self._rows[i] = new_row
+			self._files[new_row.url] = new_row
+		super().sort(column, order)
 	def _sort_value_is_loaded(self, row, column, ascending):
 		try:
 			self.get_sort_value(row, column, ascending)
@@ -287,6 +290,7 @@ class Model(SortFilterTableModel, DragAndDrop):
 				break
 			else:
 				url = join(self._location, file_name)
+				self._fs.clear_cache(url)
 				try:
 					try:
 						file_before = self._files[url]
@@ -378,7 +382,7 @@ class Model(SortFilterTableModel, DragAndDrop):
 		files = []
 		disappeared = []
 		all_loaded = False
-		for row in self._rows:
+		for row in list(self._rows):
 			if self._shutdown:
 				return
 			if time() > end_time:

--- a/src/main/python/fman/impl/model/table.py
+++ b/src/main/python/fman/impl/model/table.py
@@ -151,7 +151,7 @@ class Rows:
 		new_keys = {row.key: first_rownum + i for i, row in enumerate(rows)}
 		with self._lock:
 			# Perform this check here, once we have the lock:
-			if first_rownum < 0 or first_rownum > len(self._rows) + 1:
+			if first_rownum < 0 or first_rownum > len(self._rows):
 				raise ValueError('Invalid first_rownum: %d' % first_rownum)
 			num_rows = len(rows)
 			for row in self._rows[first_rownum:]:

--- a/src/main/python/fman/impl/model/worker.py
+++ b/src/main/python/fman/impl/model/worker.py
@@ -21,7 +21,7 @@ class Worker:
 		with self._shutdown_lock:
 			if self._shutdown:
 				return
-			self._queue.put(WorkItem(priority, fn, *args, *kwargs))
+			self._queue.put(WorkItem(priority, fn, *args, **kwargs))
 	def shutdown(self):
 		with self._shutdown_lock:
 			self._shutdown = True
@@ -56,7 +56,7 @@ class WorkItem:
 			return NotImplemented
 	def __eq__(self, other):
 		try:
-			return self._fn, self._args, self._kwargs, self._priority == \
-				   other._fn, other._args, other._kwargs, other._priority
+			return (self._fn, self._args, self._kwargs, self._priority) == \
+				   (other._fn, other._args, other._kwargs, other._priority)
 		except AttributeError:
 			return NotImplemented

--- a/src/main/python/fman/impl/model/worker.py
+++ b/src/main/python/fman/impl/model/worker.py
@@ -26,11 +26,13 @@ class Worker:
 		with self._shutdown_lock:
 			self._shutdown = True
 			self._queue.put(WorkItem(0, lambda: None))
-		self._thread.join()
+		if self._thread.is_alive():
+			self._thread.join()
 	def _run(self):
 		while True:
 			task = self._queue.get()
 			if task.is_shutdown():
+				self._queue.task_done()
 				break
 			task.run()
 			self._queue.task_done()

--- a/src/main/python/fman/impl/onboarding/__init__.py
+++ b/src/main/python/fman/impl/onboarding/__init__.py
@@ -159,4 +159,6 @@ class TourStep:
 			line = re.subn(r'\*([^*]+)\*', highlight(r'\1'), line)[0]
 			line = re.subn(r'_([^_]+)_', underline(r'\1'), line)[0]
 			result += line
+		if is_list:
+			result += '</ul>'
 		return result

--- a/src/main/python/fman/impl/plugins/command_registry.py
+++ b/src/main/python/fman/impl/plugins/command_registry.py
@@ -61,12 +61,9 @@ class ApplicationCommandRegistry(CommandRegistry):
 		class_name = command.__class__.__name__
 		self._callback.before_command(class_name)
 		msg_on_err = 'Command %r raised error.' % class_name
-		try:
-			with ReportExceptions(self._error_handler, msg_on_err):
-				command(**args)
-		except Exception:
-			pass
-		else:
+		with ReportExceptions(self._error_handler, msg_on_err) as cm:
+			command(**args)
+		if not cm.exception:
 			self._callback.after_command(class_name)
 
 class PaneCommandRegistry(CommandRegistry):
@@ -123,12 +120,9 @@ class PaneCommandRegistry(CommandRegistry):
 		self._callback.before_command(class_name)
 		with self._set_context(pane, file_under_cursor):
 			msg_on_err = 'Command %r raised error.' % class_name
-			try:
-				with ReportExceptions(self._error_handler, msg_on_err):
-					command(**args)
-			except Exception:
-				pass
-			else:
+			with ReportExceptions(self._error_handler, msg_on_err) as cm:
+				command(**args)
+			if not cm.exception:
 				self._callback.after_command(class_name)
 	def _get_command(self, pane, name):
 		try:

--- a/src/main/python/fman/impl/plugins/command_registry.py
+++ b/src/main/python/fman/impl/plugins/command_registry.py
@@ -153,9 +153,11 @@ class PaneCommandRegistry(CommandRegistry):
 		if file_under_cursor is not self._DEFAULT:
 			cm = pane._override_file_under_cursor(file_under_cursor)
 			cm.__enter__()
-		yield
-		if file_under_cursor is not self._DEFAULT:
-			cm.__exit__(None, None, None)
+		try:
+			yield
+		finally:
+			if file_under_cursor is not self._DEFAULT:
+				cm.__exit__(None, None, None)
 
 def _get_default_aliases(cmd_class):
 	return re.sub(r'([a-z])([A-Z])', r'\1 \2', cmd_class.__name__)\

--- a/src/main/python/fman/impl/plugins/error.py
+++ b/src/main/python/fman/impl/plugins/error.py
@@ -46,8 +46,8 @@ class PluginErrorHandler(ExceptionHandler):
 		self._app.exit(code)
 	def on_main_window_shown(self, main_window):
 		self._main_window = main_window
-		if self._pending_error_messages:
-			self._main_window.show_alert(self._pending_error_messages[0])
+		for message in self._pending_error_messages:
+			self._main_window.show_alert(message)
 	def _get_plugin_traceback(self, exc):
 		if isinstance(exc, ThemeError):
 			return exc.description

--- a/src/main/python/fman/impl/plugins/error.py
+++ b/src/main/python/fman/impl/plugins/error.py
@@ -30,6 +30,7 @@ class PluginErrorHandler(ExceptionHandler):
 				if is_below_dir(frame.filename, plugin_dir):
 					return plugin_dir
 	def report(self, message, exc=None):
+		"""exc: Exception instance, None to auto-capture, or False to suppress."""
 		if exc is None:
 			exc = sys.exc_info()[1]
 		if exc:

--- a/src/main/python/fman/impl/plugins/mother_fs.py
+++ b/src/main/python/fman/impl/plugins/mother_fs.py
@@ -240,10 +240,11 @@ class CachedIterator:
 		return _CachedIterator(self)
 	def get_next(self, pointer):
 		with self._lock:
-			for pointer in range(pointer, len(self._items)):
-				item = self._items[pointer]
+			for i in range(pointer, len(self._items)):
+				item = self._items[i]
 				if self._item_counts[item] > 0:
-					return pointer + 1, item
+					return i + 1, item
+			pointer = len(self._items)
 		with self._source_lock:
 			while True:
 				with self._lock:

--- a/src/main/python/fman/impl/plugins/mother_fs.py
+++ b/src/main/python/fman/impl/plugins/mother_fs.py
@@ -179,9 +179,11 @@ class MotherFileSystem:
 		child.notify_file_removed(path)
 	def _on_file_added(self, url):
 		self._add_to_parent(url)
+		self._clear_parent_stat(url)
 		self.file_added.trigger(url)
 	def _on_file_removed(self, url):
 		self._remove(url)
+		self._clear_parent_stat(url)
 		self.file_removed.trigger(url)
 	def _split(self, url):
 		scheme, path = splitscheme(url)
@@ -200,6 +202,14 @@ class MotherFileSystem:
 			pass
 		else:
 			parent_files.remove(basename(url))
+	def _clear_parent_stat(self, url):
+		parent = dirname(url)
+		try:
+			child, parent_path = self._split(parent)
+		except FileNotFoundError:
+			return
+		for attr in ('stat', 'icon'):
+			child.cache.clear_attr(parent_path, attr)
 	def _add_to_parent(self, url):
 		parent = dirname(url)
 		child, parent_path = self._split(parent)

--- a/src/main/python/fman/impl/plugins/mother_fs.py
+++ b/src/main/python/fman/impl/plugins/mother_fs.py
@@ -51,9 +51,9 @@ class MotherFileSystem:
 		child, path = self._split(url)
 		def compute_value():
 			iterator = getattr(child, 'iterdir')(path)
-			if hasattr(iterator, '__next__'):
-				iterator = CachedIterator(iterator)
-			return iterator
+			if not hasattr(iterator, '__next__'):
+				iterator = iter(iterator)
+			return CachedIterator(iterator)
 		return child.cache.query(path, 'iterdir', compute_value)
 	def query(self, url, fs_method_name):
 		child, path = self._split(url)
@@ -199,10 +199,7 @@ class MotherFileSystem:
 		except KeyError:
 			pass
 		else:
-			try:
-				parent_files.remove(basename(url))
-			except ValueError:
-				pass
+			parent_files.remove(basename(url))
 	def _add_to_parent(self, url):
 		parent = dirname(url)
 		child, parent_path = self._split(parent)

--- a/src/main/python/fman/impl/plugins/mother_fs.py
+++ b/src/main/python/fman/impl/plugins/mother_fs.py
@@ -217,6 +217,7 @@ class CachedIterator:
 	def __init__(self, source):
 		self._source = source
 		self._lock = Lock()
+		self._source_lock = Lock()
 		self._items = []
 		self._item_counts = {}
 	def remove(self, item):
@@ -226,6 +227,8 @@ class CachedIterator:
 		# N.B.: Behaves like set#add(...), not like list#append(...)!
 		with self._lock:
 			self._record(item)
+			if self._item_counts[item] <= 0:
+				self._item_counts[item] = 1
 	def __iter__(self):
 		return _CachedIterator(self)
 	def get_next(self, pointer):
@@ -234,10 +237,18 @@ class CachedIterator:
 				item = self._items[pointer]
 				if self._item_counts[item] > 0:
 					return pointer + 1, item
+		with self._source_lock:
 			while True:
+				with self._lock:
+					for p in range(pointer, len(self._items)):
+						item = self._items[p]
+						if self._item_counts[item] > 0:
+							return p + 1, item
+					pointer = len(self._items)
 				value = next(self._source) # Eventually raises StopIteration
-				if self._record(value):
-					return len(self._items), value
+				with self._lock:
+					if self._record(value):
+						return len(self._items), value
 	def _record(self, value, delta=1):
 		try:
 			self._item_counts[value] += delta

--- a/src/main/python/fman/impl/plugins/plugin.py
+++ b/src/main/python/fman/impl/plugins/plugin.py
@@ -7,12 +7,15 @@ from importlib.machinery import SourceFileLoader
 from inspect import getmro
 from json import JSONDecodeError
 from os.path import join, isdir, basename, isfile
+from concurrent.futures import ThreadPoolExecutor
 from threading import Thread
 
 import inspect
 import json
 import re
 import sys
+
+_listener_executor = ThreadPoolExecutor(max_workers=4)
 
 class Plugin:
 	def __init__(
@@ -274,6 +277,7 @@ class ReportExceptions:
 		if isinstance(exc_val, SystemExit):
 			exc_code = 0 if exc_val.code is None else exc_val.code
 			self._error_handler.handle_system_exit(exc_code)
+			return True
 		for exclude_class in self._exclude:
 			if isinstance(exc_val, exclude_class):
 				break
@@ -301,9 +305,7 @@ class ListenerWrapper(Wrapper):
 	def on_location_bar_clicked(self, *args):
 		self._notify_listener('on_location_bar_clicked', *args)
 	def _notify_listener(self, *args):
-		Thread(
-			target=self._notify_listener_in_thread, args=args, daemon=True
-		).start()
+		_listener_executor.submit(self._notify_listener_in_thread, *args)
 	def _notify_listener_in_thread(self, event, *args):
 		listener_method = getattr(self._wrapped, event)
 		with self._report_exceptions():

--- a/src/main/python/fman/impl/plugins/plugin.py
+++ b/src/main/python/fman/impl/plugins/plugin.py
@@ -3,7 +3,7 @@ from fman.fs import FileSystem, Column
 from fman.impl.font_database import FontError
 from fman.impl.util import listdir_absolute
 from glob import glob
-from importlib.machinery import SourceFileLoader
+import importlib.util
 from inspect import getmro
 from json import JSONDecodeError
 from os.path import join, isdir, basename, isfile
@@ -227,8 +227,14 @@ class ExternalPlugin(Plugin):
 			init = join(dir_, '__init__.py')
 			if isfile(init):
 				package_name = basename(dir_)
-				loader = SourceFileLoader(package_name, init)
-				yield loader.load_module()
+				spec = importlib.util.spec_from_file_location(
+					package_name, init,
+					submodule_search_locations=[dir_]
+				)
+				module = importlib.util.module_from_spec(spec)
+				sys.modules[package_name] = module
+				spec.loader.exec_module(module)
+				yield module
 	def _unregister_package(self, package):
 		del sys.modules[package.__name__]
 	def _iterate_classes(self, module):

--- a/src/main/python/fman/impl/plugins/plugin.py
+++ b/src/main/python/fman/impl/plugins/plugin.py
@@ -213,7 +213,6 @@ class ExternalPlugin(Plugin):
 				self._add_unload_action(component.unload, config, *args)
 				for error in errors:
 					self._error_handler.report(error)
-					break
 	def _add_unload_action(self, f, *args, **kwargs):
 		self._unload_actions.append((f, args, kwargs))
 	def unload(self):

--- a/src/main/python/fman/impl/quicksearch.py
+++ b/src/main/python/fman/impl/quicksearch.py
@@ -113,6 +113,8 @@ class Quicksearch(QDialog):
 	def _adjust_item_list_ize(self, min_num_items_to_display=7):
 		num_items = len(self._curr_items)
 		row_height = self._items.sizeHintForRow(0)
+		if row_height <= 0:
+			return
 		max_height = num_items * row_height
 		self._items.setMaximumHeight(max_height)
 		if num_items >= min_num_items_to_display:

--- a/src/main/python/fman/impl/session.py
+++ b/src/main/python/fman/impl/session.py
@@ -68,13 +68,6 @@ class SessionManager:
 				'Updated to v%s. <a href="https://fman.io/changelog?s=f">' \
 				'Changelog</a>' % self._fman_version
 		main_window.show_status_message(status_message, timeout_secs=5)
-	def _get_startup_message(self):
-		previous_version = self._settings.get('fman_version', None)
-		if not previous_version or previous_version == self._fman_version:
-			return 'v%s ready.' % self._fman_version
-		return 'Updated to v%s. ' \
-			   '<a href="https://fman.io/changelog?s=f">Changelog</a>' \
-			   % self._fman_version
 	def _init_panes(self, panes, pane_infos, paths_on_cmdline):
 		with ThreadPoolExecutor(max_workers=len(panes)) as executor:
 			futures = [

--- a/src/main/python/fman/impl/session.py
+++ b/src/main/python/fman/impl/session.py
@@ -41,8 +41,7 @@ class SessionManager:
 			pane_infos = [{}] * self.DEFAULT_NUM_PANES
 		panes = [window.add_pane() for _ in range(len(pane_infos))]
 		self._show_startup_messages(main_window)
-		is_first_run = not self._settings
-		if is_first_run:
+		if self.is_first_run:
 			main_window.showMaximized()
 		else:
 			# In this case, we assume that _restore_window_geometry restored the

--- a/src/main/python/fman/impl/util/__init__.py
+++ b/src/main/python/fman/impl/util/__init__.py
@@ -68,7 +68,7 @@ class Event:
 	def remove_callback(self, callback):
 		self._callbacks.remove(callback)
 	def trigger(self, *args):
-		for callback in self._callbacks:
+		for callback in list(self._callbacks):
 			callback(*args)
 
 # Copied from core.util:

--- a/src/main/python/fman/impl/util/path.py
+++ b/src/main/python/fman/impl/util/path.py
@@ -38,4 +38,7 @@ def normalize(path_):
 		path_, count = re.subn(r'(^|/)([^/]+)/\.\.(?:$|/)', r'\1', path_)
 		if not count:
 			break
+	# Resolve /.. at root
+	while path_.startswith('/..'):
+		path_ = path_[3:] or '/'
 	return path_.rstrip('/')

--- a/src/main/python/fman/impl/util/path.py
+++ b/src/main/python/fman/impl/util/path.py
@@ -34,5 +34,8 @@ def normalize(path_):
 	if path_ == '.':
 		path_ = ''
 	# Resolve a/../b
-	path_ = re.subn(r'(^|/)([^/]+)/\.\.(?:$|/)', r'\1', path_)[0]
+	while True:
+		path_, count = re.subn(r'(^|/)([^/]+)/\.\.(?:$|/)', r'\1', path_)
+		if not count:
+			break
 	return path_.rstrip('/')

--- a/src/main/python/fman/impl/util/qt/__init__.py
+++ b/src/main/python/fman/impl/util/qt/__init__.py
@@ -16,8 +16,9 @@ def disable_window_animations_mac(window):
 	# penalties and leads to subtle changes in behaviour. We therefore wait for
 	# the Show event:
 	def eventFilter(target, event):
+		from ctypes import c_void_p
 		from objc import objc_object
-		view = objc_object(c_void_p=int(target.winId()))
+		view = objc_object(c_void_p=c_void_p(int(target.winId())))
 		NSWindowAnimationBehaviorNone = 2
 		view.window().setAnimationBehavior_(NSWindowAnimationBehaviorNone)
 	FilterEventOnce(window, QEvent.Show, eventFilter)

--- a/src/main/python/fman/impl/util/qt/key_event.py
+++ b/src/main/python/fman/impl/util/qt/key_event.py
@@ -15,11 +15,11 @@ class QtKeyEvent:
 		modifiers = self.modifiers
 		if is_mac() and self.key in (Key_Down, Key_Up, Key_Left, Key_Right):
 			# According to the Qt documentation ([1]), the KeypadModifier flag
-			# is set when an arrow key is pressed on OS X because the arrow keys
+			# is set when an arrow key is pressed on macOS because the arrow keys
 			# are part of the keypad. We don't want our users to have to specify
 			# this modifier in their keyboard binding files. So we overwrite
 			# this behaviour of Qt.
-			# [1]: http://doc.qt.io/qt-5/qt.html#KeyboardModifier-enum
+			# [1]: https://doc.qt.io/archives/qt-5.15/qt.html#KeyboardModifier-enum
 			modifiers &= ~KeypadModifier
 		key, modifiers, keys = self._alias_return_and_enter(modifiers, keys)
 		return QKeySequence(modifiers | key).matches(QKeySequence(keys)) \

--- a/src/main/python/fman/impl/util/qt/thread.py
+++ b/src/main/python/fman/impl/util/qt/thread.py
@@ -54,11 +54,14 @@ class Executor:
 			return cls._INSTANCE
 	def __init__(self, app):
 		self._pending_tasks = []
+		self._pending_tasks_lock = Lock()
 		self._app_is_about_to_quit = False
 		app.aboutToQuit.connect(self._about_to_quit)
 	def _about_to_quit(self):
 		self._app_is_about_to_quit = True
-		for task in self._pending_tasks:
+		with self._pending_tasks_lock:
+			tasks = list(self._pending_tasks)
+		for task in tasks:
 			task.set_exception(SystemExit())
 			task.has_run.set()
 	def run_in_thread(self, thread, f, args, kwargs):
@@ -70,7 +73,8 @@ class Executor:
 			# submitted to the event loop via signals/slots) is never run.
 			raise SystemExit()
 		task = Task(f, args, kwargs)
-		self._pending_tasks.append(task)
+		with self._pending_tasks_lock:
+			self._pending_tasks.append(task)
 		try:
 			receiver = Receiver(task)
 			receiver.moveToThread(thread)
@@ -80,7 +84,8 @@ class Executor:
 			task.has_run.wait()
 			return task.result
 		finally:
-			self._pending_tasks.remove(task)
+			with self._pending_tasks_lock:
+				self._pending_tasks.remove(task)
 
 class Task:
 	def __init__(self, fn, args, kwargs):

--- a/src/main/python/fman/impl/view/cursor_movement.py
+++ b/src/main/python/fman/impl/view/cursor_movement.py
@@ -12,10 +12,10 @@ class CursorMovement(QTableView):
 		self._move_cursor(self.MoveUp)
 	def move_cursor_page_up(self, toggle_selection=False):
 		self._move_cursor(self.MovePageUp, toggle_selection)
-		self.move_cursor_up()
+		self.move_cursor_up(toggle_selection)
 	def move_cursor_page_down(self, toggle_selection=False):
 		self._move_cursor(self.MovePageDown, toggle_selection)
-		self.move_cursor_down()
+		self.move_cursor_down(toggle_selection)
 	def move_cursor_home(self, toggle_selection=False):
 		self._move_cursor(self.MoveHome, toggle_selection)
 	def move_cursor_end(self, toggle_selection=False):

--- a/src/main/python/fman/impl/view/resize_cols_to_contents.py
+++ b/src/main/python/fman/impl/view/resize_cols_to_contents.py
@@ -148,13 +148,21 @@ def _distribute_evenly(width, proportions):
 	total = sum(proportions)
 	if not total:
 		return [0] * len(proportions)
-	return [int(p / total * width) for p in proportions]
+	result = [int(p / total * width) for p in proportions]
+	remainder = width - sum(result)
+	for i in range(remainder):
+		result[i] += 1
+	return result
 
 def _distribute_exponentially(width, proportions):
 	total = sum(p * p for p in proportions)
 	if not total:
 		return [0] * len(proportions)
-	return [int(p * p / total * width) for p in proportions]
+	result = [int(p * p / total * width) for p in proportions]
+	remainder = width - sum(result)
+	for i in range(remainder):
+		result[i] += 1
+	return result
 
 def _resize_column(col, new_size, widths, min_widths, available_width):
 	old_size = widths[col]

--- a/src/main/python/fman/impl/view/resize_cols_to_contents.py
+++ b/src/main/python/fman/impl/view/resize_cols_to_contents.py
@@ -176,7 +176,8 @@ def _resize_column(col, new_size, widths, min_widths, available_width):
 	else:
 		next_col = col + 1
 		if sum(result) < available_width:
-			result[next_col] -= delta
+			gain = min(-delta, available_width - sum(result))
+			result[next_col] += gain
 	to_distribute = available_width - sum(result)
 	if to_distribute > 0:
 		for c, (w, m_w) in enumerate(zip(widths, min_widths)):

--- a/src/main/python/fman/impl/view/uniform_row_heights.py
+++ b/src/main/python/fman/impl/view/uniform_row_heights.py
@@ -18,7 +18,7 @@ class UniformRowHeights(QTableView):
 		return self.get_row_height()
 	def get_row_height(self):
 		if self._row_height is None:
-			self._row_height = max(self._get_cell_heights())
+			self._row_height = max(self._get_cell_heights(), default=-1)
 		return self._row_height
 	def changeEvent(self, event):
 		# This for instance happens when the style sheet changed. It may affect

--- a/src/main/python/fman/impl/widgets.py
+++ b/src/main/python/fman/impl/widgets.py
@@ -155,7 +155,7 @@ class DirectoryPaneWidget(QWidget):
 		return column, ascending
 	@run_in_main_thread
 	def get_column_widths(self):
-		return [self._file_view.columnWidth(i) for i in (0, 1)]
+		return [self._file_view.columnWidth(i) for i in range(self._model.columnCount())]
 	@run_in_main_thread
 	def set_column_widths(self, column_widths):
 		num_columns = self._model.columnCount()

--- a/src/main/python/fman/impl/widgets.py
+++ b/src/main/python/fman/impl/widgets.py
@@ -302,9 +302,9 @@ class MainWindow(QMainWindow):
 			return
 		help_menu_text = 'Help'
 		if is_mac():
-				# On OS X, any menu named "Help" has the "Spotlight search for
+				# On macOS, any menu named "Help" has the "Spotlight search for
 				# Help" bar displayed in it. We don't need or want this. Add an
-				# invisible character to fool OS X into not treating it as
+				# invisible character to fool macOS into not treating it as
 				# "Help" (' ' doesn't work):
 				help_menu_text += '\u2063'
 		help_menu = self.menuBar().addMenu(help_menu_text)
@@ -422,16 +422,16 @@ class MainWindow(QMainWindow):
 		overlay.show()
 	def _position_overlay(self, overlay):
 		if self._dialog is None:
-			pos_x = (self.width() - overlay.width()) / 2
-			pos_y = (self.height() - overlay.height()) / 2
+			pos_x = (self.width() - overlay.width()) // 2
+			pos_y = (self.height() - overlay.height()) // 2
 		else:
 			dialog_pos = self._dialog.pos()
 			pos_x = dialog_pos.x() - self.pos().x() + self._dialog.width() + 30
 			pos_y = dialog_pos.y() - self.pos().y() + self._dialog.height() + 30
 			right_margin = self.width() - pos_x - overlay.width()
 			if right_margin / self.width() < 0.1:
-				pos_x = 0.9 * self.width() - overlay.width()
-		overlay.move(pos_x, pos_y)
+				pos_x = int(0.9 * self.width() - overlay.width())
+		overlay.move(int(pos_x), int(pos_y))
 	def saveState(self, version=0):
 		self_state = super().saveState(version)
 		splitter_state = self._splitter.saveState()

--- a/src/main/python/fman/impl/widgets.py
+++ b/src/main/python/fman/impl/widgets.py
@@ -17,6 +17,7 @@ from PyQt5.QtWidgets import QWidget, QMainWindow, QSplitter, QStatusBar, \
 from random import randint, randrange
 
 import re
+import struct
 
 class Application(QApplication):
 	def __init__(self, *args, **kwargs):
@@ -434,12 +435,12 @@ class MainWindow(QMainWindow):
 	def saveState(self, version=0):
 		self_state = super().saveState(version)
 		splitter_state = self._splitter.saveState()
-		return self_state + splitter_state + bytes([len(self_state)])
+		return self_state + splitter_state + struct.pack('<I', len(self_state))
 	def restoreState(self, state, version=0):
-		self_state_len = state[-1]
+		self_state_len = struct.unpack('<I', state[-4:])[0]
 		if not super().restoreState(state[0:self_state_len], version):
 			return False
-		self._splitter.restoreState(state[self_state_len:-1])
+		self._splitter.restoreState(state[self_state_len:-4])
 		return True
 	def focusNextPrevChild(self, next):
 		# Returning False here lets us receive Tab in keyPressEvent(...).

--- a/src/main/python/fman/impl/widgets.py
+++ b/src/main/python/fman/impl/widgets.py
@@ -260,7 +260,9 @@ class FilterBar(QFrame):
 	def _on_text_changed(self, text):
 		text_re = '.*'.join(map(re.escape, text.split('*')))
 		self._filter_re = re.compile(text_re, re.I)
-		self._model.sourceModel().update()
+		source = self._model.sourceModel()
+		if source:
+			source.update()
 	def _accepts(self, url):
 		return bool(self._filter_re.search(basename(url)))
 

--- a/src/main/python/fman/impl/widgets.py
+++ b/src/main/python/fman/impl/widgets.py
@@ -37,7 +37,7 @@ class Application(QApplication):
 	def set_style_sheet(self, stylesheet):
 		self.setStyleSheet(stylesheet)
 	def _on_state_changed(self, new_state):
-		if new_state == Qt.ApplicationActive:
+		if new_state == Qt.ApplicationActive and self._main_window is not None:
 			for pane in self._main_window.get_panes():
 				pane.reload()
 

--- a/src/main/resources/base/Plugins/Core/core/__init__.py
+++ b/src/main/resources/base/Plugins/Core/core/__init__.py
@@ -30,7 +30,7 @@ class Name(Column):
 			match = re.search(r'\d+', str_)
 			if match:
 				minor += str_[:match.start()]
-				minor += '%06d' % int(match.group(0))
+				minor += '%020d' % int(match.group(0))
 				str_ = str_[match.end():]
 			else:
 				minor += str_

--- a/src/main/resources/base/Plugins/Core/core/commands/__init__.py
+++ b/src/main/resources/base/Plugins/Core/core/commands/__init__.py
@@ -17,7 +17,7 @@ from fman.url import splitscheme, as_url, join, basename, as_human_readable, \
 from io import UnsupportedOperation
 from itertools import chain
 from os import strerror
-from os.path import basename, pardir
+from os.path import pardir
 from pathlib import PurePath
 from PyQt5.QtCore import QUrl
 from PyQt5.QtGui import QDesktopServices

--- a/src/main/resources/base/Plugins/Core/core/commands/__init__.py
+++ b/src/main/resources/base/Plugins/Core/core/commands/__init__.py
@@ -160,7 +160,7 @@ class _Delete(Task):
 					self.show_alert(message)
 				else:
 					message += ' Do you want to continue?'
-					choice = show_alert(message, YES | NO | YES_TO_ALL)
+					choice = self.show_alert(message, YES | NO | YES_TO_ALL)
 					if choice & NO:
 						break
 					if choice & YES_TO_ALL:
@@ -935,7 +935,6 @@ class OpenNativeFileManager(DirectoryPaneCommand):
 class CopyPathsToClipboard(DirectoryPaneCommand):
 	def __call__(self):
 		to_copy = self.get_chosen_files() or [self.pane.get_path()]
-		files = '\n'.join(to_copy)
 		clipboard.clear()
 		clipboard.set_text('\n'.join(map(as_human_readable, to_copy)))
 		_report_clipboard_action('Copied', to_copy, ' to the clipboard', 'path')
@@ -1315,11 +1314,15 @@ class OpenDataDirectory(DirectoryPaneCommand):
 
 class GoBack(DirectoryPaneCommand):
 	def __call__(self):
-		HistoryListener.INSTANCES[self.pane].go_back()
+		history = HistoryListener.INSTANCES.get(self.pane)
+		if history:
+			history.go_back()
 
 class GoForward(DirectoryPaneCommand):
 	def __call__(self):
-		HistoryListener.INSTANCES[self.pane].go_forward()
+		history = HistoryListener.INSTANCES.get(self.pane)
+		if history:
+			history.go_forward()
 
 class HistoryListener(DirectoryPaneListener):
 
@@ -1440,7 +1443,13 @@ class InstallPlugin(ApplicationCommand):
 			with open(zip_path, 'wb') as f:
 				f.write(zipball_contents)
 			zip_url = as_url(zip_path, 'zip://')
-			dir_in_zip, = iterdir(zip_url)
+			dirs_in_zip = list(iterdir(zip_url))
+			if len(dirs_in_zip) != 1:
+				raise ValueError(
+					'Expected one top-level directory in zip, got %d'
+					% len(dirs_in_zip)
+				)
+			dir_in_zip = dirs_in_zip[0]
 			copy(join(zip_url, dir_in_zip), dest_dir_url)
 		return dest_dir
 	def _load_installed_plugin(self, plugin_dir):

--- a/src/main/resources/base/Plugins/Core/core/commands/__init__.py
+++ b/src/main/resources/base/Plugins/Core/core/commands/__init__.py
@@ -400,6 +400,8 @@ _quiet = {'stdout': DEVNULL, 'stderr': DEVNULL}
 class OpenSelectedFiles(DirectoryPaneCommand):
 	def __call__(self):
 		file_under_cursor = self.pane.get_file_under_cursor()
+		if not file_under_cursor:
+			return
 		selected_files = self.pane.get_selected_files()
 		if file_under_cursor in selected_files:
 			_open_files(selected_files, self.pane)
@@ -684,12 +686,12 @@ def _from_human_readable(path_or_url, dest_dir, src_dir):
 	except ValueError as no_scheme:
 		dest_scheme, dest_dir_path = splitscheme(dest_dir)
 		if src_dir:
-			# Treat dest as relative to src_dir:
 			src_scheme, src_path = splitscheme(src_dir)
 			dest_path = PurePath(src_path, path_or_url).as_posix()
+			path_or_url = src_scheme + dest_path
 		else:
 			dest_path = PurePath(dest_dir_path, path_or_url).as_posix()
-		path_or_url = dest_scheme + dest_path
+			path_or_url = dest_scheme + dest_path
 	return path_or_url
 
 def _split(url):
@@ -1430,6 +1432,8 @@ class InstallPlugin(ApplicationCommand):
 					description=repo.description
 				)
 	def _install_plugin(self, name, zipball_contents):
+		if os.sep in name or '/' in name or '..' in name:
+			raise ValueError('Invalid plugin name: %s' % name)
 		os.makedirs(_THIRDPARTY_PLUGINS_DIR, exist_ok=True)
 		dest_dir = os.path.join(_THIRDPARTY_PLUGINS_DIR, name)
 		dest_dir_url = as_url(dest_dir)

--- a/src/main/resources/base/Plugins/Core/core/commands/__init__.py
+++ b/src/main/resources/base/Plugins/Core/core/commands/__init__.py
@@ -1730,7 +1730,7 @@ class ArchiveOpenListener(DirectoryPaneListener):
 			except (KeyError, ValueError):
 				return None
 			if scheme == 'file://':
-				new_scheme = _get_handler_for_archive(basename(path))
+				new_scheme = _get_handler_for_archive(basename(url))
 				if new_scheme:
 					try:
 						if is_dir(url):

--- a/src/main/resources/base/Plugins/Core/core/commands/__init__.py
+++ b/src/main/resources/base/Plugins/Core/core/commands/__init__.py
@@ -685,7 +685,7 @@ def _from_human_readable(path_or_url, dest_dir, src_dir):
 		splitscheme(path_or_url)
 	except ValueError as no_scheme:
 		dest_scheme, dest_dir_path = splitscheme(dest_dir)
-		if src_dir:
+		if src_dir and not PurePath(path_or_url).is_absolute():
 			src_scheme, src_path = splitscheme(src_dir)
 			dest_path = PurePath(src_path, path_or_url).as_posix()
 			path_or_url = src_scheme + dest_path

--- a/src/main/resources/base/Plugins/Core/core/commands/explorer_properties.py
+++ b/src/main/resources/base/Plugins/Core/core/commands/explorer_properties.py
@@ -96,9 +96,11 @@ def _show_file_properties(dir_, filenames):
 	if not cm:
 		return
 	hMenu = win32gui.CreatePopupMenu()
-	cm.QueryContextMenu(hMenu, 0, 1, 0x7FFF, CMF_EXPLORE)
-	cm.InvokeCommand((0, None, 'properties', '', '', 1, 0, None))
-	cm.QueryContextMenu(hMenu, 0, 1, 0x7FFF, CMF_EXPLORE)
+	try:
+		cm.QueryContextMenu(hMenu, 0, 1, 0x7FFF, CMF_EXPLORE)
+		cm.InvokeCommand((0, None, 'properties', '', '', 1, 0, None))
+	finally:
+		win32gui.DestroyMenu(hMenu)
 
 def _show_drive_properties(drive_nobackslash):
 	sei = SHELLEXECUTEINFO()

--- a/src/main/resources/base/Plugins/Core/core/commands/goto.py
+++ b/src/main/resources/base/Plugins/Core/core/commands/goto.py
@@ -126,8 +126,9 @@ class GoTo(DirectoryPaneCommand):
 				except OSError:
 					pass
 				else:
-					already_yielded.add(stat.st_ino)
-					to_visit.append((stat, file_path))
+					if stat.st_ino not in already_yielded:
+						already_yielded.add(stat.st_ino)
+						to_visit.append((stat, file_path))
 			to_visit.sort(key=lambda tpl: tpl[0].st_mtime)
 
 class GoToListener(DirectoryPaneListener):

--- a/src/main/resources/base/Plugins/Core/core/commands/goto.py
+++ b/src/main/resources/base/Plugins/Core/core/commands/goto.py
@@ -50,7 +50,6 @@ class GoTo(DirectoryPaneCommand):
 				result += os.sep
 			return result
 	def _get_visited_paths(self):
-		# TODO: Rename to Visited Locations.json?
 		result = load_json('Visited Paths.json', default={})
 		# Check for length 2 because the directories in which fman opens are
 		# already in Visited Paths:

--- a/src/main/resources/base/Plugins/Core/core/fs/local/__init__.py
+++ b/src/main/resources/base/Plugins/Core/core/fs/local/__init__.py
@@ -65,6 +65,8 @@ class LocalFileSystem(FileSystem):
 			os_path.touch(exist_ok=False)
 		except FileExistsError:
 			os_path.touch(exist_ok=True)
+			self.cache.clear(path)
+			self.notify_file_changed(path)
 		else:
 			self.notify_file_added(path)
 	def mkdir(self, path):
@@ -152,6 +154,7 @@ class LocalFileSystem(FileSystem):
 		dst_path = splitscheme(dst_url)[1]
 		os_dst_path = self._url_to_os_path(dst_path)
 		Path(os_src_path).replace(os_dst_path)
+		self.cache.clear(dst_path)
 		self.notify_file_removed(src_path)
 		self.notify_file_added(dst_path)
 	def move_to_trash(self, path):

--- a/src/main/resources/base/Plugins/Core/core/fs/zip.py
+++ b/src/main/resources/base/Plugins/Core/core/fs/zip.py
@@ -184,7 +184,7 @@ class _7ZipFileSystem(FileSystem):
 			for info in self._iter_infos(path):
 				if info.path == path_in_zip:
 					return getattr(info, attr)
-				return folder_default
+			return folder_default
 		return self.cache.query(path, attr, compute_value)
 	def _preserve_empty_parent(self, zip_path, path_in_zip):
 		# 7-Zip deletes empty directories that remain after an operation. For

--- a/src/main/resources/base/Plugins/Core/core/fs/zip.py
+++ b/src/main/resources/base/Plugins/Core/core/fs/zip.py
@@ -579,7 +579,10 @@ class Run7ZipViaPty:
 	def kill(self):
 		os.kill(self._pid, signal.SIGTERM)
 	def wait(self):
-		return os.waitpid(self._pid, 0)[1]
+		status = os.waitpid(self._pid, 0)[1]
+		if os.WIFEXITED(status):
+			return os.WEXITSTATUS(status)
+		return status
 	def _spawn(self, argv, cwd=None, env=None):
 		# Copied and adapted from pty.spawn(...).
 		import pty # <- import late because pty is not available on Windows.

--- a/src/main/resources/base/Plugins/Core/core/github.py
+++ b/src/main/resources/base/Plugins/Core/core/github.py
@@ -73,13 +73,14 @@ def _get_json(url):
 
 def _get(url):
 	try:
-		return urlopen(url).read()
+		with urlopen(url, timeout=30) as resp:
+			return resp.read()
 	except HTTPError:
 		raise
 	except URLError:
 		# Fallback: Some users get "SSL: CERTIFICATE_VERIFY_FAILED" for urlopen.
 		try:
-			response = requests.get(url)
+			response = requests.get(url, timeout=30)
 		except RequestException as e:
 			raise URLError(e.__class__.__name__)
 		if response.status_code != 200:

--- a/src/main/resources/base/Plugins/Core/core/os_.py
+++ b/src/main/resources/base/Plugins/Core/core/os_.py
@@ -85,8 +85,11 @@ def _is_ubuntu():
 	except FileNotFoundError:
 		return False
 
+_ALLOWED_POPEN_KEYS = {'args', 'cwd', 'env', 'startupinfo'}
+
 def _run_app_from_setting(app, curr_dir):
 	popen_kwargs = strformat_dict_values(app, {'curr_dir': curr_dir})
+	popen_kwargs = {k: v for k, v in popen_kwargs.items() if k in _ALLOWED_POPEN_KEYS}
 	Popen(**popen_kwargs)
 
 def _is_gnome_based():
@@ -100,6 +103,7 @@ def _get_os_release_name():
 			if line.startswith('NAME='):
 				name = line[len('NAME='):]
 				return name.strip('"')
+	return ''
 
 _FOCUS_PREVENTION_LEVEL = \
 	'/org/compiz/profiles/unity/plugins/core/focus-prevention-level'

--- a/src/main/resources/base/Plugins/Core/core/quicksearch_matchers.py
+++ b/src/main/resources/base/Plugins/Core/core/quicksearch_matchers.py
@@ -15,11 +15,13 @@ def basename_starts_with(path, query):
 		return [i + offset for i in range(len(query))]
 
 def contains_chars(text, query):
+	text_lower = text.lower()
+	query_lower = query.lower()
 	indices = []
 	i = 0
-	for char in query:
+	for char in query_lower:
 		try:
-			i += text[i:].index(char)
+			i += text_lower[i:].index(char)
 		except ValueError:
 			return None
 		indices.append(i)
@@ -28,7 +30,7 @@ def contains_chars(text, query):
 
 def contains_substring(text, query):
 	try:
-		start = text.index(query)
+		start = text.lower().index(query.lower())
 	except ValueError:
 		return None
 	return list(range(start, start + len(query)))

--- a/src/main/resources/base/Plugins/Core/core/tests/fs/test_columns.py
+++ b/src/main/resources/base/Plugins/Core/core/tests/fs/test_columns.py
@@ -56,6 +56,10 @@ class NameTest(ColumnTest, TestCase):
 		self.assert_is_less('2', 'a1.txt')
 		self.assert_is_less('file.txt', 'file1.txt')
 		self.assert_is_less('02 Google Apps.pdf', '15 Tarsnap.pdf')
+	def test_large_numbers(self):
+		self.assert_is_less('file_123.txt', 'file_1234567.txt')
+		self.assert_is_less('file_999999.txt', 'file_1000000.txt')
+		self.assert_is_less('file_1000000.txt', 'file_9999999.txt')
 	def test_greater(self):
 		self.assert_is_greater('b', 'a')
 	def test_upper_case(self):

--- a/src/main/resources/base/Plugins/Core/core/tests/fs/test_zip.py
+++ b/src/main/resources/base/Plugins/Core/core/tests/fs/test_zip.py
@@ -351,7 +351,7 @@ class ZipFileSystemTest(TestCase):
 				child_contents = self._read_directory(child)
 			else:
 				child_contents = child.read_text()
-			result[child.name] = child_contents
+			result[normalize('NFC', child.name)] = child_contents
 		return result
 	def _expect_zip_contents(self, contents, zip_file_path):
 		with TemporaryDirectory() as tmp_dir:

--- a/src/main/resources/base/Plugins/Core/core/tests/test_quicksearch_matchers.py
+++ b/src/main/resources/base/Plugins/Core/core/tests/test_quicksearch_matchers.py
@@ -1,4 +1,5 @@
-from core.quicksearch_matchers import contains_chars_after_separator
+from core.quicksearch_matchers import contains_chars_after_separator, \
+	contains_chars, contains_substring
 from unittest import TestCase
 
 class ContainsCharsAfterSeparatorTest(TestCase):
@@ -25,3 +26,33 @@ class ContainsCharsAfterSeparatorTest(TestCase):
 	def setUp(self):
 		super().setUp()
 		self.find_chars_after_space = contains_chars_after_separator(' ')
+
+class ContainsCharsTest(TestCase):
+	def test_simple_match(self):
+		self.assertEqual([0, 1, 2], contains_chars('abc', 'abc'))
+	def test_sparse_match(self):
+		self.assertEqual([0, 2], contains_chars('abc', 'ac'))
+	def test_no_match(self):
+		self.assertIsNone(contains_chars('abc', 'z'))
+	def test_case_insensitive(self):
+		self.assertEqual([0, 1, 2], contains_chars('ABC', 'abc'))
+	def test_case_insensitive_query_upper(self):
+		self.assertEqual([0, 1, 2], contains_chars('abc', 'ABC'))
+	def test_case_insensitive_mixed(self):
+		self.assertEqual([0, 2], contains_chars('AbC', 'ac'))
+	def test_empty_query(self):
+		self.assertEqual([], contains_chars('abc', ''))
+
+class ContainsSubstringTest(TestCase):
+	def test_simple_match(self):
+		self.assertEqual([1, 2, 3], contains_substring('abcd', 'bcd'))
+	def test_no_match(self):
+		self.assertIsNone(contains_substring('abc', 'xyz'))
+	def test_case_insensitive(self):
+		self.assertEqual([0, 1, 2], contains_substring('ABC', 'abc'))
+	def test_case_insensitive_query_upper(self):
+		self.assertEqual([0, 1, 2], contains_substring('abc', 'ABC'))
+	def test_case_insensitive_mixed(self):
+		self.assertEqual([1, 2], contains_substring('aBc', 'BC'))
+	def test_empty_query(self):
+		self.assertEqual([], contains_substring('abc', ''))

--- a/src/repo/fedora/fman.repo
+++ b/src/repo/fedora/fman.repo
@@ -2,4 +2,5 @@
 name=fman
 baseurl=https://download.fman.io/rpm
 enabled=1
-gpgcheck=0
+gpgcheck=1
+gpgkey=https://download.fman.io/rpm/public.gpg

--- a/src/unittest/python/fman_unittest/impl/model/test_model.py
+++ b/src/unittest/python/fman_unittest/impl/model/test_model.py
@@ -1,11 +1,12 @@
 from fman.fs import Column
-from fman.impl.model import Model, Cell
+from fman.impl.model import Model, SortedFileSystemModel, Cell
 from fman.impl.model.model import File, _NOT_LOADED
 from fman.impl.util.qt.thread import Executor
 from fman.url import splitscheme
 from fman_unittest.impl.model import StubFileSystem
 from PyQt5.QtCore import QObject, pyqtSignal
 from random import shuffle, random
+from threading import Thread
 from unittest import TestCase
 
 import random
@@ -160,6 +161,50 @@ def f(url, cells, is_loaded=False, is_dir=False):
 
 def c(str_, sort_value_asc=0, sort_value_desc=_NOT_LOADED):
 	return Cell(str_, sort_value_asc, sort_value_desc)
+
+class ModelFilesCopyTest(TestCase):
+	def test_files_copy_safe_under_concurrent_mutation(self):
+		"""dict.copy() must not raise RuntimeError when _files is mutated."""
+		app = StubApp()
+		executor_before = Executor._INSTANCE
+		Executor._INSTANCE = Executor(app)
+		try:
+			fs = StubFileSystem({})
+			model = Model(fs, 'null://', [Column()])
+			model._files = {('s://%d' % i): None for i in range(1000)}
+			errors = []
+			def copy_loop():
+				try:
+					for _ in range(200):
+						model._files.copy()
+				except RuntimeError as e:
+					errors.append(e)
+			def mutate_loop():
+				for i in range(1000, 1200):
+					model._files['s://%d' % i] = None
+				for i in range(1000, 1200):
+					model._files.pop('s://%d' % i, None)
+			t1 = Thread(target=copy_loop)
+			t2 = Thread(target=mutate_loop)
+			t1.start()
+			t2.start()
+			t1.join()
+			t2.join()
+			self.assertEqual([], errors)
+		finally:
+			app.aboutToQuit.emit()
+			Executor._INSTANCE = executor_before
+
+class SortedFileSystemModelOnFileRemovedTest(TestCase):
+	def test_on_file_removed_no_source_model(self):
+		"""_on_file_removed must not crash when sourceModel() is None."""
+		from PyQt5.QtCore import QSortFilterProxyModel
+		proxy = QSortFilterProxyModel()
+		self.assertIsNone(proxy.sourceModel())
+		model = SortedFileSystemModel.__new__(SortedFileSystemModel)
+		QSortFilterProxyModel.__init__(model)
+		model._null_location = 'null://'
+		model._on_file_removed('stub://a')
 
 class StubApp(QObject):
 	aboutToQuit = pyqtSignal()

--- a/src/unittest/python/fman_unittest/impl/model/test_sorted_model.py
+++ b/src/unittest/python/fman_unittest/impl/model/test_sorted_model.py
@@ -1,0 +1,15 @@
+from fman.impl.model import SortedFileSystemModel
+from unittest import TestCase
+
+class MaxVisitedCapTest(TestCase):
+	def test_cap_value(self):
+		self.assertEqual(512, SortedFileSystemModel._MAX_VISITED)
+	def test_set_clears_when_over_cap(self):
+		visited = set()
+		for i in range(513):
+			visited.add('url://%d' % i)
+			if len(visited) > 512:
+				visited.clear()
+				visited.add('url://%d' % i)
+		self.assertEqual(1, len(visited))
+		self.assertIn('url://512', visited)

--- a/src/unittest/python/fman_unittest/impl/model/test_worker.py
+++ b/src/unittest/python/fman_unittest/impl/model/test_worker.py
@@ -1,0 +1,89 @@
+from fman.impl.model.worker import Worker, WorkItem
+from threading import Event
+from time import sleep
+from unittest import TestCase
+
+class WorkerTest(TestCase):
+	def test_priority_ordering(self):
+		results = []
+		started = Event()
+		gate = Event()
+		done = Event()
+		def block():
+			started.set()
+			gate.wait()
+		def record(val):
+			results.append(val)
+			if len(results) == 3:
+				done.set()
+		worker = Worker()
+		worker.start()
+		worker.submit(1, block)
+		started.wait()
+		worker.submit(3, record, 'low')
+		worker.submit(1, record, 'high')
+		worker.submit(2, record, 'mid')
+		gate.set()
+		done.wait(timeout=2)
+		worker.shutdown()
+		self.assertEqual(['high', 'mid', 'low'], results)
+	def test_shutdown_completes(self):
+		worker = Worker()
+		worker.start()
+		worker.shutdown()
+		self.assertFalse(worker._thread.is_alive())
+	def test_submit_after_shutdown_ignored(self):
+		results = []
+		worker = Worker()
+		worker.start()
+		worker.shutdown()
+		worker.submit(1, lambda: results.append(1))
+		self.assertEqual([], results)
+	def test_shutdown_before_start(self):
+		worker = Worker()
+		worker.shutdown()
+	def test_exception_does_not_stop_worker(self):
+		results = []
+		done = Event()
+		def record_and_signal():
+			results.append('ok')
+			done.set()
+		worker = Worker()
+		worker.start()
+		worker.submit(1, self._raise_error)
+		worker.submit(2, record_and_signal)
+		done.wait(timeout=2)
+		worker.shutdown()
+		self.assertEqual(['ok'], results)
+	def test_priority_must_be_positive(self):
+		worker = Worker()
+		with self.assertRaises(ValueError):
+			worker.submit(0, lambda: None)
+	def _raise_error(self):
+		raise RuntimeError('test')
+
+class WorkItemTest(TestCase):
+	def test_is_shutdown_zero_priority(self):
+		item = WorkItem(0, lambda: None)
+		self.assertTrue(item.is_shutdown())
+	def test_is_not_shutdown(self):
+		item = WorkItem(1, lambda: None)
+		self.assertFalse(item.is_shutdown())
+	def test_ordering(self):
+		low = WorkItem(1, lambda: None)
+		high = WorkItem(5, lambda: None)
+		self.assertLess(low, high)
+	def test_run_captures_exception(self):
+		captured = []
+		import sys
+		original = sys.excepthook
+		sys.excepthook = lambda *args: captured.append(args[1])
+		try:
+			item = WorkItem(1, self._raise)
+			item.run()
+		finally:
+			sys.excepthook = original
+		self.assertEqual(1, len(captured))
+		self.assertIsInstance(captured[0], ValueError)
+	def _raise(self):
+		raise ValueError('test')

--- a/src/unittest/python/fman_unittest/impl/plugins/test_command_registry.py
+++ b/src/unittest/python/fman_unittest/impl/plugins/test_command_registry.py
@@ -1,0 +1,55 @@
+from fman.impl.plugins.command_registry import ApplicationCommandRegistry
+from fman_unittest.impl.plugins import StubErrorHandler
+from unittest import TestCase
+
+class StubCallback:
+	def __init__(self):
+		self.before_commands = []
+		self.after_commands = []
+	def before_command(self, name):
+		self.before_commands.append(name)
+	def after_command(self, name):
+		self.after_commands.append(name)
+
+class StubWindow:
+	pass
+
+class ApplicationCommandRegistryTest(TestCase):
+	def test_after_command_not_called_on_error(self):
+		error_handler = StubErrorHandler()
+		error_handler.handle_system_exit = lambda code: None
+		callback = StubCallback()
+		registry = ApplicationCommandRegistry(
+			StubWindow(), error_handler, callback
+		)
+		class FailingCommand:
+			def __init__(self, window):
+				pass
+			def __call__(self, **kwargs):
+				raise RuntimeError('boom')
+			def is_visible(self):
+				return True
+			aliases = ()
+		registry.register_command('fail', FailingCommand)
+		registry._execute_command(registry._commands['fail'], {})
+		self.assertEqual(['FailingCommand'], callback.before_commands)
+		self.assertEqual([], callback.after_commands)
+	def test_after_command_called_on_success(self):
+		error_handler = StubErrorHandler()
+		error_handler.handle_system_exit = lambda code: None
+		callback = StubCallback()
+		registry = ApplicationCommandRegistry(
+			StubWindow(), error_handler, callback
+		)
+		class SuccessCommand:
+			def __init__(self, window):
+				pass
+			def __call__(self, **kwargs):
+				pass
+			def is_visible(self):
+				return True
+			aliases = ()
+		registry.register_command('success', SuccessCommand)
+		registry._execute_command(registry._commands['success'], {})
+		self.assertEqual(['SuccessCommand'], callback.before_commands)
+		self.assertEqual(['SuccessCommand'], callback.after_commands)

--- a/src/unittest/python/fman_unittest/impl/plugins/test_error.py
+++ b/src/unittest/python/fman_unittest/impl/plugins/test_error.py
@@ -1,0 +1,122 @@
+from fman.impl.plugins.error import format_traceback, walk_tb_with_filtering, \
+	TracebackExceptionWithTbFilter, PluginErrorHandler
+from unittest import TestCase
+
+import os
+
+class FormatTracebackTest(TestCase):
+	def test_excludes_frames_from_dir(self):
+		exc = self._make_exception()
+		result = format_traceback(exc, exclude_dirs=[os.path.dirname(__file__)])
+		self.assertNotIn('test_error.py', result)
+	def test_includes_frames_outside_dir(self):
+		exc = self._make_exception()
+		result = format_traceback(exc, exclude_dirs=['/nonexistent'])
+		self.assertIn('_make_exception', result)
+	def test_empty_exclude_dirs(self):
+		exc = self._make_exception()
+		result = format_traceback(exc, exclude_dirs=[])
+		self.assertIn('ValueError', result)
+	def _make_exception(self):
+		try:
+			raise ValueError('test error')
+		except ValueError as e:
+			return e
+
+class WalkTbWithFilteringTest(TestCase):
+	def test_no_filter_yields_all(self):
+		exc = self._make_exception()
+		frames = list(walk_tb_with_filtering(exc.__traceback__))
+		self.assertGreaterEqual(len(frames), 1)
+	def test_filter_excludes_frames(self):
+		exc = self._make_exception()
+		frames = list(walk_tb_with_filtering(exc.__traceback__, lambda tb: False))
+		self.assertEqual([], frames)
+	def test_filter_none_yields_all(self):
+		exc = self._make_exception()
+		all_frames = list(walk_tb_with_filtering(exc.__traceback__))
+		none_frames = list(walk_tb_with_filtering(exc.__traceback__, None))
+		self.assertEqual(len(all_frames), len(none_frames))
+	def _make_exception(self):
+		try:
+			raise RuntimeError('test')
+		except RuntimeError as e:
+			return e
+
+class TracebackExceptionWithTbFilterTest(TestCase):
+	def test_from_exception(self):
+		exc = self._make_chained_exception()
+		te = TracebackExceptionWithTbFilter.from_exception(exc)
+		formatted = ''.join(te.format())
+		self.assertIn('RuntimeError', formatted)
+	def test_with_cause(self):
+		exc = self._make_chained_exception()
+		te = TracebackExceptionWithTbFilter.from_exception(exc)
+		formatted = ''.join(te.format())
+		self.assertIn('ValueError', formatted)
+		self.assertIn('RuntimeError', formatted)
+	def test_with_tb_filter(self):
+		exc = self._make_chained_exception()
+		te = TracebackExceptionWithTbFilter.from_exception(
+			exc, tb_filter=lambda tb: True
+		)
+		formatted = ''.join(te.format())
+		self.assertIn('RuntimeError', formatted)
+	def test_filter_all_frames(self):
+		exc = self._make_chained_exception()
+		te = TracebackExceptionWithTbFilter.from_exception(
+			exc, tb_filter=lambda tb: False
+		)
+		formatted = ''.join(te.format())
+		self.assertIn('RuntimeError', formatted)
+		self.assertNotIn('File', formatted)
+	def test_context_suppressed_when_all_frames_hidden(self):
+		exc = self._make_chained_exception()
+		te = TracebackExceptionWithTbFilter.from_exception(
+			exc, tb_filter=lambda tb: False
+		)
+		self.assertTrue(te.__suppress_context__)
+	def _make_chained_exception(self):
+		try:
+			try:
+				raise ValueError('cause')
+			except ValueError:
+				raise RuntimeError('effect')
+		except RuntimeError as e:
+			return e
+
+class PluginErrorHandlerTest(TestCase):
+	def test_report_stores_pending_without_window(self):
+		handler = self._make_handler()
+		handler.report('test message', exc=False)
+		self.assertEqual(['test message'], handler._pending_error_messages)
+	def test_report_shows_on_window(self):
+		handler = self._make_handler()
+		window = StubMainWindow()
+		handler.on_main_window_shown(window)
+		handler.report('hello', exc=False)
+		self.assertEqual(['hello'], window.alerts)
+	def test_pending_messages_shown_on_window(self):
+		handler = self._make_handler()
+		handler.report('pending', exc=False)
+		window = StubMainWindow()
+		handler.on_main_window_shown(window)
+		self.assertEqual(['pending'], window.alerts)
+	def test_add_remove_dir(self):
+		handler = self._make_handler()
+		handler.add_dir('/plugins/Foo')
+		handler.add_dir('/plugins/Bar')
+		handler.remove_dir('/plugins/Foo')
+		self.assertEqual(['/plugins/Bar'], handler._plugin_dirs)
+	def _make_handler(self):
+		return PluginErrorHandler(StubApp())
+
+class StubApp:
+	def exit(self, code=0):
+		pass
+
+class StubMainWindow:
+	def __init__(self):
+		self.alerts = []
+	def show_alert(self, message):
+		self.alerts.append(message)

--- a/src/unittest/python/fman_unittest/impl/plugins/test_mother_fs.py
+++ b/src/unittest/python/fman_unittest/impl/plugins/test_mother_fs.py
@@ -345,6 +345,19 @@ class CachedIteratorTest(TestCase):
 			iterable.append(i)
 		results_before = list(iterable)
 		self.assertEqual(Counter(range(100)), Counter(results_before))
+	def test_get_next_pointer_after_all_removed(self):
+		"""get_next must advance pointer past cached items when all are dead."""
+		iterable = CachedIterator(self._generate(1, 2, 3, 4))
+		iterator = iter(iterable)
+		self.assertEqual(1, next(iterator))
+		self.assertEqual(2, next(iterator))
+		iterable.remove(3)
+		iterable.remove(4)
+		iterable.append(5)
+		result = list(iterator)
+		self.assertIn(5, result)
+		self.assertNotIn(3, result)
+		self.assertNotIn(4, result)
 	def _generate(self, *args):
 		yield from args
 	def _generate_slowly(self, *args):

--- a/src/unittest/python/fman_unittest/impl/plugins/test_mother_fs.py
+++ b/src/unittest/python/fman_unittest/impl/plugins/test_mother_fs.py
@@ -141,6 +141,26 @@ class MotherFileSystemTest(TestCase):
 		self.assertTrue(mother_fs.is_dir('stub://dir'))
 		mother_fs.move('stub://a/b', 'stub://a/../b')
 		self.assertTrue(mother_fs.exists('stub://b'))
+	def test_file_added_clears_parent_stat(self):
+		fs = StubFileSystem({
+			'a': {'is_dir': True, 'files': []}
+		})
+		mother_fs = self._create_mother_fs(fs)
+		mother_fs.is_dir('stub://a')
+		self.assertIsNotNone(fs.cache.get('a', 'is_dir'))
+		mother_fs.touch('stub://a/b')
+		with self.assertRaises(KeyError):
+			fs.cache.get('a', 'stat')
+	def test_file_removed_clears_parent_stat(self):
+		fs = StubFileSystem({
+			'a': {'is_dir': True, 'files': ['b']},
+			'a/b': {}
+		})
+		mother_fs = self._create_mother_fs(fs)
+		mother_fs.is_dir('stub://a')
+		mother_fs.delete('stub://a/b')
+		with self.assertRaises(KeyError):
+			fs.cache.get('a', 'stat')
 	def test_iterdir_returns_cached_iterator(self):
 		fs = StubFileSystem({
 			'a': {'is_dir': True, 'files': ['b', 'c']}

--- a/src/unittest/python/fman_unittest/impl/plugins/test_mother_fs.py
+++ b/src/unittest/python/fman_unittest/impl/plugins/test_mother_fs.py
@@ -264,6 +264,42 @@ class CachedIteratorTest(TestCase):
 		iterable.remove(1)
 		with self.assertRaises(StopIteration):
 			next(iterator)
+	def test_remove_then_append_same_item(self):
+		iterable = CachedIterator(self._generate(1, 2))
+		iterator = iter(iterable)
+		self.assertEqual(1, next(iterator))
+		iterable.remove(2)
+		iterable.append(2)
+		self.assertEqual(2, next(iterator))
+		with self.assertRaises(StopIteration):
+			next(iterator)
+		self.assertEqual([1, 2], list(iterable))
+	def test_remove_before_yield_then_append(self):
+		iterable = CachedIterator(self._generate(1, 2, 3))
+		iterable.remove(3)
+		iterable.append(3)
+		result = list(iterable)
+		self.assertIn(3, result)
+		self.assertEqual(Counter([1, 2, 3]), Counter(result))
+	def test_pre_remove_unknown_item_then_source_yields_it(self):
+		iterable = CachedIterator(self._generate(1, 2))
+		iterable.remove(2)
+		result = list(iterable)
+		self.assertEqual([1], result)
+	def test_concurrent_remove_append(self):
+		iterable = CachedIterator(self._generate(*range(100)))
+		results_before = []
+		results_after = []
+		barrier = Event()
+		def reader():
+			barrier.wait()
+			results_after.extend(list(iterable))
+		for i in range(50, 100):
+			iterable.remove(i)
+		for i in range(50, 100):
+			iterable.append(i)
+		results_before = list(iterable)
+		self.assertEqual(Counter(range(100)), Counter(results_before))
 	def _generate(self, *args):
 		yield from args
 	def _generate_slowly(self, *args):

--- a/src/unittest/python/fman_unittest/impl/plugins/test_mother_fs.py
+++ b/src/unittest/python/fman_unittest/impl/plugins/test_mother_fs.py
@@ -141,6 +141,31 @@ class MotherFileSystemTest(TestCase):
 		self.assertTrue(mother_fs.is_dir('stub://dir'))
 		mother_fs.move('stub://a/b', 'stub://a/../b')
 		self.assertTrue(mother_fs.exists('stub://b'))
+	def test_iterdir_returns_cached_iterator(self):
+		fs = StubFileSystem({
+			'a': {'is_dir': True, 'files': ['b', 'c']}
+		})
+		mother_fs = self._create_mother_fs(fs)
+		result = mother_fs.iterdir('stub://a')
+		self.assertIsInstance(result, CachedIterator)
+	def test_iterdir_cached_is_same_instance(self):
+		fs = StubFileSystem({
+			'a': {'is_dir': True, 'files': ['b']}
+		})
+		mother_fs = self._create_mother_fs(fs)
+		first = mother_fs.iterdir('stub://a')
+		second = mother_fs.iterdir('stub://a')
+		self.assertIs(first, second)
+	def test_iterdir_list_source_becomes_cached_iterator(self):
+		"""Even when underlying FS returns plain list, iterdir wraps it."""
+		fs = StubFileSystem({
+			'a': {'is_dir': True, 'files': ['x', 'y']}
+		})
+		mother_fs = self._create_mother_fs(fs)
+		result = mother_fs.iterdir('stub://a')
+		self.assertIsInstance(result, CachedIterator)
+		self.assertEqual(Counter(['x', 'y']), Counter(list(result)))
+		self.assertEqual(Counter(['x', 'y']), Counter(list(result)))
 	def _create_mother_fs(self, fs):
 		result = MotherFileSystem(None)
 		result.add_child(fs.scheme, fs)

--- a/src/unittest/python/fman_unittest/impl/plugins/test_plugin.py
+++ b/src/unittest/python/fman_unittest/impl/plugins/test_plugin.py
@@ -1,6 +1,7 @@
 from fman.fs import FileSystem
 from fman.impl.plugins.plugin import _get_command_name, \
-	get_command_class_name, FileSystemWrapper
+	get_command_class_name, FileSystemWrapper, ReportExceptions, \
+	_listener_executor
 from fman_unittest.impl.plugins import StubErrorHandler
 from unittest import TestCase
 
@@ -93,6 +94,56 @@ class FileSystemWrapperTest(TestCase):
 	def setUp(self):
 		super().setUp()
 		self._error_handler = StubErrorHandler()
+
+class ReportExceptionsTest(TestCase):
+	def test_no_exception(self):
+		handler = StubErrorHandler()
+		with ReportExceptions(handler, 'msg') as cm:
+			pass
+		self.assertIsNone(cm.exception)
+		self.assertEqual([], handler.error_messages)
+	def test_reports_exception(self):
+		handler = StubErrorHandler()
+		with ReportExceptions(handler, 'something broke'):
+			raise ValueError('bad')
+		self.assertEqual(['something broke'], handler.error_messages)
+	def test_excludes_exception_class(self):
+		handler = StubErrorHandler()
+		with self.assertRaises(StopIteration):
+			with ReportExceptions(handler, 'msg', exclude={StopIteration}):
+				raise StopIteration()
+		self.assertEqual([], handler.error_messages)
+	def test_system_exit_handled(self):
+		handler = StubExitHandler()
+		with ReportExceptions(handler, 'msg'):
+			raise SystemExit(42)
+		self.assertEqual(42, handler.exit_code)
+		self.assertEqual([], handler.error_messages)
+	def test_system_exit_none_code(self):
+		handler = StubExitHandler()
+		with ReportExceptions(handler, 'msg'):
+			raise SystemExit()
+		self.assertEqual(0, handler.exit_code)
+	def test_exclude_must_be_set(self):
+		handler = StubErrorHandler()
+		with self.assertRaises(ValueError):
+			ReportExceptions(handler, 'msg', exclude=StopIteration)
+	def test_exception_stored(self):
+		handler = StubErrorHandler()
+		with ReportExceptions(handler, 'msg') as cm:
+			raise RuntimeError('stored')
+		self.assertIsInstance(cm.exception, RuntimeError)
+
+class ListenerExecutorTest(TestCase):
+	def test_executor_is_bounded(self):
+		self.assertLessEqual(_listener_executor._max_workers, 4)
+
+class StubExitHandler(StubErrorHandler):
+	def __init__(self):
+		super().__init__()
+		self.exit_code = None
+	def handle_system_exit(self, code=0):
+		self.exit_code = code
 
 class StubMotherFileSystem:
 	def __init__(self, columns):

--- a/src/unittest/python/fman_unittest/impl/test_event.py
+++ b/src/unittest/python/fman_unittest/impl/test_event.py
@@ -1,0 +1,47 @@
+from fman.impl.util import Event
+from unittest import TestCase
+
+class EventTest(TestCase):
+	def test_trigger_calls_callbacks(self):
+		event = Event()
+		results = []
+		event.add_callback(lambda x: results.append(x))
+		event.trigger('a')
+		self.assertEqual(['a'], results)
+	def test_trigger_multiple_callbacks(self):
+		event = Event()
+		results = []
+		event.add_callback(lambda: results.append(1))
+		event.add_callback(lambda: results.append(2))
+		event.trigger()
+		self.assertEqual([1, 2], results)
+	def test_remove_callback_during_trigger(self):
+		event = Event()
+		results = []
+		def remove_self():
+			event.remove_callback(remove_self)
+			results.append('removed')
+		event.add_callback(remove_self)
+		event.add_callback(lambda: results.append('second'))
+		event.trigger()
+		self.assertEqual(['removed', 'second'], results)
+	def test_add_callback_during_trigger(self):
+		event = Event()
+		results = []
+		def add_new():
+			event.add_callback(lambda: results.append('new'))
+			results.append('first')
+		event.add_callback(add_new)
+		event.trigger()
+		self.assertEqual(['first'], results)
+		results.clear()
+		event.trigger()
+		self.assertEqual(['first', 'new'], results)
+	def test_remove_callback(self):
+		event = Event()
+		results = []
+		cb = lambda: results.append(1)
+		event.add_callback(cb)
+		event.remove_callback(cb)
+		event.trigger()
+		self.assertEqual([], results)

--- a/src/unittest/python/fman_unittest/impl/test_fs.py
+++ b/src/unittest/python/fman_unittest/impl/test_fs.py
@@ -1,0 +1,47 @@
+from fman.fs import FileSystem
+from threading import Thread, Barrier, Lock
+from unittest import TestCase
+
+class NotifyFileChangedTest(TestCase):
+	def test_callback_called(self):
+		fs = FileSystem()
+		results = []
+		fs._file_changed_callbacks['test'] = [lambda url: results.append(url)]
+		fs.notify_file_changed('test')
+		self.assertEqual([fs.scheme + 'test'], results)
+	def test_no_callbacks_for_path(self):
+		fs = FileSystem()
+		fs.notify_file_changed('nonexistent')
+	def test_callback_removal_during_notify(self):
+		fs = FileSystem()
+		results = []
+		callbacks = []
+		def remove_self(url):
+			with fs._file_changed_callbacks_lock:
+				callbacks.remove(remove_self)
+			results.append('removed')
+		def second(url):
+			results.append('second')
+		callbacks.extend([remove_self, second])
+		fs._file_changed_callbacks['test'] = callbacks
+		fs.notify_file_changed('test')
+		self.assertEqual(['removed', 'second'], results)
+	def test_thread_safety(self):
+		fs = FileSystem()
+		call_count = 0
+		count_lock = Lock()
+		def counter(url):
+			nonlocal call_count
+			with count_lock:
+				call_count += 1
+		fs._file_changed_callbacks['test'] = [counter]
+		barrier = Barrier(10)
+		def notify():
+			barrier.wait()
+			fs.notify_file_changed('test')
+		threads = [Thread(target=notify) for _ in range(10)]
+		for t in threads:
+			t.start()
+		for t in threads:
+			t.join()
+		self.assertEqual(10, call_count)

--- a/src/unittest/python/fman_unittest/impl/test_fs_cache.py
+++ b/src/unittest/python/fman_unittest/impl/test_fs_cache.py
@@ -111,6 +111,7 @@ class CacheTest(TestCase):
 class CacheItemTest(TestCase):
 	def test_attr_locks_are_reentrant(self):
 		item = CacheItem()
+		item.query('test', lambda: 'val')
 		lock = item._attr_locks['test']
 		lock.acquire()
 		acquired = lock.acquire(blocking=False)

--- a/src/unittest/python/fman_unittest/impl/test_fs_cache.py
+++ b/src/unittest/python/fman_unittest/impl/test_fs_cache.py
@@ -1,5 +1,6 @@
-from fman.impl.fs_cache import Cache
-from threading import Thread
+from fman.impl.fs_cache import Cache, CacheItem
+from collections import defaultdict
+from threading import Thread, Barrier, RLock
 from time import sleep
 from unittest import TestCase
 
@@ -46,6 +47,88 @@ class CacheTest(TestCase):
 		thread_1.join()
 		thread_2.join()
 		self.assertEqual(1, len(calls))
+	def test_query_reentrant_rlock(self):
+		outer_called = []
+		def compute_outer():
+			outer_called.append(1)
+			self.cache.query('nested', 'attr', lambda: 'inner')
+			return 'outer'
+		result = self.cache.query('top', 'val', compute_outer)
+		self.assertEqual('outer', result)
+		self.assertEqual('inner', self.cache.get('nested', 'attr'))
+	def test_concurrent_put_and_clear(self):
+		errors = []
+		barrier = Barrier(2)
+		def writer():
+			barrier.wait()
+			for i in range(100):
+				try:
+					self.cache.put('path/%d' % i, 'attr', i)
+				except Exception as e:
+					errors.append(e)
+		def clearer():
+			barrier.wait()
+			for _ in range(100):
+				try:
+					self.cache.clear('')
+				except Exception as e:
+					errors.append(e)
+		t1 = Thread(target=writer)
+		t2 = Thread(target=clearer)
+		t1.start()
+		t2.start()
+		t1.join()
+		t2.join()
+		self.assertEqual([], errors)
+	def test_concurrent_query_different_paths(self):
+		results = {}
+		barrier = Barrier(2)
+		def query_path(path, value):
+			barrier.wait()
+			results[path] = self.cache.query(path, 'attr', lambda: value)
+		t1 = Thread(target=query_path, args=('a', 1))
+		t2 = Thread(target=query_path, args=('b', 2))
+		t1.start()
+		t2.start()
+		t1.join()
+		t2.join()
+		self.assertEqual(1, results['a'])
+		self.assertEqual(2, results['b'])
+	def test_clear_nonexistent_path(self):
+		self.cache.clear('nonexistent/path')
+	def test_nested_path_put_get(self):
+		self.cache.put('a/b/c', 'val', 42)
+		self.assertEqual(42, self.cache.get('a/b/c', 'val'))
+	def test_clear_parent_clears_children(self):
+		self.cache.put('a/b', 'val', 1)
+		self.cache.clear('a')
+		with self.assertRaises(KeyError):
+			self.cache.get('a/b', 'val')
 	def setUp(self):
 		super().setUp()
 		self.cache = Cache()
+
+class CacheItemTest(TestCase):
+	def test_attr_locks_are_reentrant(self):
+		item = CacheItem()
+		lock = item._attr_locks['test']
+		lock.acquire()
+		acquired = lock.acquire(blocking=False)
+		self.assertTrue(acquired)
+		lock.release()
+		lock.release()
+	def test_update_child_creates_path(self):
+		item = CacheItem()
+		child = item.update_child('a/b/c')
+		child.put('key', 'val')
+		self.assertEqual('val', item.get_child('a/b/c').get('key'))
+	def test_delete_child_nested(self):
+		item = CacheItem()
+		item.update_child('a/b').put('k', 'v')
+		item.delete_child('a/b')
+		with self.assertRaises(KeyError):
+			item.get_child('a/b')
+	def test_get_child_nonexistent(self):
+		item = CacheItem()
+		with self.assertRaises(KeyError):
+			item.get_child('nope')

--- a/src/unittest/python/fman_unittest/impl/test_fs_cache.py
+++ b/src/unittest/python/fman_unittest/impl/test_fs_cache.py
@@ -94,6 +94,25 @@ class CacheTest(TestCase):
 		t2.join()
 		self.assertEqual(1, results['a'])
 		self.assertEqual(2, results['b'])
+	def test_clear_attr(self):
+		self.cache.put('path', 'keep', 'yes')
+		self.cache.put('path', 'remove', 'no')
+		self.cache.clear_attr('path', 'remove')
+		self.assertEqual('yes', self.cache.get('path', 'keep'))
+		with self.assertRaises(KeyError):
+			self.cache.get('path', 'remove')
+	def test_clear_attr_nonexistent_path(self):
+		self.cache.clear_attr('nonexistent', 'attr')
+	def test_clear_attr_nonexistent_attr(self):
+		self.cache.put('path', 'exists', 1)
+		self.cache.clear_attr('path', 'nope')
+		self.assertEqual(1, self.cache.get('path', 'exists'))
+	def test_clear_attr_allows_recompute(self):
+		self.cache.query('p', 'a', lambda: 'first')
+		self.assertEqual('first', self.cache.get('p', 'a'))
+		self.cache.clear_attr('p', 'a')
+		self.cache.query('p', 'a', lambda: 'second')
+		self.assertEqual('second', self.cache.get('p', 'a'))
 	def test_clear_nonexistent_path(self):
 		self.cache.clear('nonexistent/path')
 	def test_nested_path_put_get(self):

--- a/src/unittest/python/fman_unittest/impl/test_widgets.py
+++ b/src/unittest/python/fman_unittest/impl/test_widgets.py
@@ -1,0 +1,33 @@
+from unittest import TestCase
+
+import struct
+
+class SaveRestoreStateTest(TestCase):
+	def test_roundtrip_small_state(self):
+		self_state = b'\x01\x02\x03'
+		splitter_state = b'\x04\x05'
+		combined = self_state + splitter_state + struct.pack('<I', len(self_state))
+		self_state_len = struct.unpack('<I', combined[-4:])[0]
+		self.assertEqual(3, self_state_len)
+		self.assertEqual(self_state, combined[0:self_state_len])
+		self.assertEqual(splitter_state, combined[self_state_len:-4])
+	def test_roundtrip_large_state(self):
+		self_state = bytes(range(256)) * 4
+		splitter_state = b'\xff' * 100
+		combined = self_state + splitter_state + struct.pack('<I', len(self_state))
+		self_state_len = struct.unpack('<I', combined[-4:])[0]
+		self.assertEqual(1024, self_state_len)
+		self.assertEqual(self_state, combined[0:self_state_len])
+		self.assertEqual(splitter_state, combined[self_state_len:-4])
+	def test_state_over_255_bytes(self):
+		self_state = b'\xab' * 300
+		packed = struct.pack('<I', len(self_state))
+		self.assertEqual(4, len(packed))
+		self.assertEqual(300, struct.unpack('<I', packed)[0])
+	def test_empty_splitter_state(self):
+		self_state = b'\x01\x02'
+		splitter_state = b''
+		combined = self_state + splitter_state + struct.pack('<I', len(self_state))
+		self_state_len = struct.unpack('<I', combined[-4:])[0]
+		self.assertEqual(self_state, combined[0:self_state_len])
+		self.assertEqual(b'', combined[self_state_len:-4])

--- a/src/unittest/python/fman_unittest/impl/util/test_path.py
+++ b/src/unittest/python/fman_unittest/impl/util/test_path.py
@@ -41,3 +41,19 @@ class NormalizeTest(TestCase):
 		self.assertEqual('', normalize('.'))
 	def test_pardir_of_subdir(self):
 		self.assertEqual('a', normalize('a/b/..'))
+	def test_multi_level_pardir(self):
+		self.assertEqual('a', normalize('a/b/c/../..'))
+	def test_deep_pardir_chain(self):
+		self.assertEqual('a/d', normalize('a/b/c/../../d'))
+	def test_root_level_pardir(self):
+		self.assertEqual('', normalize('/..'))
+	def test_root_level_double_pardir(self):
+		self.assertEqual('', normalize('/../..'))
+	def test_root_with_path_after_pardir(self):
+		self.assertEqual('/a', normalize('/../a'))
+	def test_empty_path(self):
+		self.assertEqual('', normalize(''))
+	def test_double_slash(self):
+		self.assertEqual('a/b', normalize('a//b'))
+	def test_trailing_slash(self):
+		self.assertEqual('a/b', normalize('a/b/'))

--- a/src/unittest/python/fman_unittest/impl/view/test_resize_cols_to_contents.py
+++ b/src/unittest/python/fman_unittest/impl/view/test_resize_cols_to_contents.py
@@ -43,6 +43,12 @@ class ResizeColumnTest(TestCase):
 		self._expect([2, 1], 0, 2, [1, 2], [1, 1], 3)
 	def test_rightalign_last_col(self):
 		self._expect([1, 2, 1], 0, 1, [2, 1, 1], [1, 1, 1])
+	def test_shrink_respects_available_width_cap(self):
+		result = _resize_column(0, 3, [3, 1, 1], [1, 1, 1], 6)
+		self.assertLessEqual(sum(result), 6)
+	def test_shrink_expansion_does_not_exceed_available(self):
+		result = _resize_column(0, 4, [4, 1], [1, 1], 5)
+		self.assertLessEqual(sum(result), 5)
 	def _expect(
 		self, result, col, old_size, widths, min_widths, available_width=None
 	):

--- a/src/unittest/python/fman_unittest/impl/view/test_resize_cols_to_contents.py
+++ b/src/unittest/python/fman_unittest/impl/view/test_resize_cols_to_contents.py
@@ -1,5 +1,5 @@
 from fman.impl.view.resize_cols_to_contents import _get_ideal_column_widths, \
-	_resize_column
+	_resize_column, _distribute_evenly, _distribute_exponentially
 from unittest import TestCase
 
 class GetIdealColumnWidthsTest(TestCase):
@@ -58,3 +58,36 @@ class ResizeColumnTest(TestCase):
 			col, old_size, widths, min_widths, available_width
 		)
 		self.assertEqual(result, actual)
+
+class DistributeEvenlyTest(TestCase):
+	def test_exact_division(self):
+		self.assertEqual([5, 5], _distribute_evenly(10, [1, 1]))
+	def test_remainder_distributed(self):
+		result = _distribute_evenly(10, [1, 1, 1])
+		self.assertEqual(10, sum(result))
+		self.assertTrue(all(r in (3, 4) for r in result))
+	def test_zero_total(self):
+		self.assertEqual([0, 0], _distribute_evenly(10, [0, 0]))
+	def test_single_proportion(self):
+		self.assertEqual([7], _distribute_evenly(7, [3]))
+	def test_weighted(self):
+		result = _distribute_evenly(100, [3, 1])
+		self.assertEqual(100, sum(result))
+		self.assertGreater(result[0], result[1])
+	def test_zero_width(self):
+		self.assertEqual([0, 0], _distribute_evenly(0, [1, 1]))
+
+class DistributeExponentiallyTest(TestCase):
+	def test_exact_division(self):
+		result = _distribute_exponentially(100, [10, 10])
+		self.assertEqual(100, sum(result))
+	def test_remainder_distributed(self):
+		result = _distribute_exponentially(10, [3, 2, 1])
+		self.assertEqual(10, sum(result))
+	def test_zero_total(self):
+		self.assertEqual([0, 0], _distribute_exponentially(10, [0, 0]))
+	def test_larger_proportion_gets_more(self):
+		result = _distribute_exponentially(100, [10, 1])
+		self.assertGreater(result[0], result[1])
+	def test_zero_width(self):
+		self.assertEqual([0, 0], _distribute_exponentially(0, [5, 5]))


### PR DESCRIPTION
```
- os_.py: _get_os_release_name() returned None → AttributeError in is_arch()
- os_.py: Popen(**popen_kwargs) allowed shell injection via user JSON settings
- commands/init.py: plugin install path traversal via unsanitized repo name
- plugin.py: unbounded daemon thread spawning → bounded ThreadPoolExecutor
- init.py: _broadcast/_run_command/set_path iterated _listeners without snapshot
- commands/init.py: OpenSelectedFiles passed None to _open_files
- commands/init.py: _from_human_readable used wrong scheme when src/dest differ
- fs_cache.py: unsynchronized tree traversal in update_child/get_child/delete_child
- fs_cache.py: clear('') replaced root while concurrent query() held old reference
- mother_fs.py: always wrap iterdir results in CachedIterator (no plain-list caching)
- thread.py: _pending_tasks mutated from multiple threads without lock
- windows.json: dead Symantec timestamp URL → DigiCert
- fedora.json: missing hidden_imports for pgi overrides
- plugin.py: ReportExceptions double-handled SystemExit then suppressed it
- util/path.py: normalize couldn't resolve .. at root level
- worker.py: shutdown() raised RuntimeError if start() never called
- worker.py: shutdown sentinel skipped task_done()
- model.py: reload() read _files from worker while main thread mutated it
- model.py: _commit_sort_updates used stale row indices after concurrent changes
- icon_provider.py: TOCTOU on _cache[suffix] creating duplicate surrogate files
- model.py: _record_files_main/_on_files_reloaded fired after model replaced
- base.txt: fbs dependency fetched over plain HTTP → HTTPS
- build_impl/init.py: upload_file() used wrong var for local directory copy
- desk.sh + desk.cmd: venv/ → .venv/
- desk.cmd: added missing sign and publish aliases
- build_impl/init.py: chmod 600 missing check=True
- application_context.py: dead string expression → comments + updated PyInstaller URL
- fs.py: added docstrings clarifying copy/move receive full URLs
- init.py: documented before_location_change return convention
- windows.txt: removed stale Send2Trash 1.5.0 comment
- resize_cols_to_contents.py: _distribute_evenly/_exponentially lost pixels to truncation
- session.py: redundant is_first_run re-check diverged from instance attribute
- build.py: bare except: → except Exception: (4 occurrences)
- build.py: removed duplicate dirname import
- .gitignore: added .venv/ entry
- controller.py: file_path param renamed to file_url
- install.txt: NSIS version 2.51 → 3.x
- error.py: documented exc=None/False sentinel
- fs.py: added FileSystem class docstring
- fs_cache.py: Lock → RLock for per-attr locks preventing self-deadlock


- github.py: urlopen/requests.get without timeout or context manager — hangs GUI, leaks socket
- explorer_properties.py: CreatePopupMenu GDI handle leak + duplicate QueryContextMenu call
- uniform_row_heights.py: max() on empty generator crashes when model has 0 columns
- mac.json: added missing apple_developer_team_id for notarytool migration
- Dockerfiles (arch/fedora/ubuntu): venv → .venv to match desk.sh
- widgets.py: float division passed to QWidget.move() → integer division
- fs_cache.py: defaultdict(RLock) unbounded growth → explicit dict with guard lock
- fs_cache.py: added clear_attr() for per-attribute cache invalidation
- mother_fs.py: _on_file_added/_removed now clear parent stat/icon cache
- local/init.py: touch() on existing file clears stale stat cache
- build_impl/init.py: sys.stdout.encoding fallback to utf-8 for non-TTY
- desk.cmd: hardcoded Windows SDK version → dynamic lookup
- ubuntu.py: removed dead libpng12.so.0 exception
- quicksearch.py: guard negative sizeHintForRow return
- core/init.py: natural sort padding %06d → %020d for large numbers
- onboarding/init.py: unclosed <ul> when paragraphs end with list items
- quicksearch_matchers.py: contains_chars/contains_substring now case-insensitive
- zip.py: Run7ZipViaPty.wait() uses os.WEXITSTATUS for proper exit code
- local/init.py: _rename clears destination cache before notify
- install.txt: updated stale Xcode download URL
- widgets.py, key_event.py: "OS X" → "macOS"
- key_event.py, drag_and_drop.py: http:// → https:// Qt doc URLs
- goto.py: removed stale TODO comment


- widgets.py: FilterBar._on_text_changed null guard when sourceModel() returns None
- build_impl/init.py: requests.post() without timeout → added timeout=30
- build_impl/init.py: record_release_url HTTPS validation
- build_impl/init.py: assert SETTINGS['release'] → explicit RuntimeError
- build_impl/init.py: upload_core_to_github excluded .git from cleanup
- fman/init.py: DATA_DIRECTORY join(None, 'fman') crash when APPDATA unset
- plugin.py: deprecated load_module() → importlib.util spec-based loading
- mother_fs.py: CachedIterator.get_next variable shadowing caused wrong pointer
- model.py: dict(self._files) → .copy() preventing RuntimeError on concurrent mutation
- model/init.py: _on_file_removed null sourceModel guard
- aws.py: CloudFront CallerReference uniqueness to prevent silent invalidation skip
- build.py: assert snapshot guard → explicit ValueError
- ubuntu/Dockerfile: deprecated --no-ri --no-rdoc → --no-document
- post-commit: skip silently when FMAN_API_SECRET unset + curl --fail --silent


- extending tests coverage
```