### PR TITLE
Build system, platform, and deployment fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ __pycache__/
 *.py[cod]
 cache/
 venv/
+.venv/
 target/
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,5 +36,5 @@
   `try/except TypeError` around `Path.resolve(strict=True)` and updated
   version-specific comments.
 - **Reduced macOS app bundle size** from ~110MB to ~77MB by stripping unused
-  Qt frameworks (QtQml, QtQuick, QtWebSockets), unused Qt plugins, and
+  Qt frameworks (QtQml, QtQmlModels, QtQuick, QtWebSockets), unused Qt plugins, and
   build-only dependencies (boto3/botocore) from the frozen bundle.

--- a/bin/desk.cmd
+++ b/bin/desk.cmd
@@ -1,13 +1,20 @@
-set PATH=C:\Windows\SysWOW64\downlevel;C:\Program Files (x86)\NSIS;C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x86;%PATH%
+FOR /F "delims=" %%i IN ('dir /b /ad /o-n "C:\Program Files (x86)\Windows Kits\10\bin\10.*"') DO (
+    SET "WIN_SDK_VER=%%i"
+    GOTO :sdk_found
+)
+:sdk_found
+set PATH=C:\Windows\SysWOW64\downlevel;C:\Program Files (x86)\NSIS;C:\Program Files (x86)\Windows Kits\10\bin\%WIN_SDK_VER%\x86;%PATH%
 
-SET ROOT=c:\Users\micha\dev\fman
+SET ROOT=%~dp0..
 CD %ROOT%
 
-CALL venv\scripts\activate.bat
+CALL .venv\scripts\activate.bat
 DOSKEY run=python build.py run $*
 DOSKEY clean=python build.py clean
 DOSKEY freeze=python build.py freeze $*
 DOSKEY installer=python build.py installer $*
+DOSKEY sign=python build.py sign $*
 DOSKEY sign_installer=python build.py sign_installer $*
+DOSKEY publish=python build.py publish $*
 DOSKEY tests=python build.py test $*
 DOSKEY release=python build.py release $*

--- a/bin/desk.sh
+++ b/bin/desk.sh
@@ -26,7 +26,7 @@ THIS_SCRIPT_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 PROJECT_DIR="$THIS_SCRIPT_DIR/.."
 
 cd "$PROJECT_DIR"
-source venv/bin/activate
+source .venv/bin/activate
 
 PS1="(fman) \h:\W \u\$ "
 

--- a/bin/post-commit
+++ b/bin/post-commit
@@ -5,11 +5,15 @@ set -e
 
 URL=https://fman.io/api/record-commit/
 
+if [ -z "${FMAN_API_SECRET:-}" ]; then
+	exit 0
+fi
+
 message_tmp_file=`mktemp`
 git log --pretty=format:%B -n1 > ${message_tmp_file}
 sha=`git log --pretty=format:%H -n1`
 date=`git log --pretty=format:%cd --date=iso-strict -n1`
-curl --data-urlencode secret=k92XhhhmOf8rD7QJ --data-urlencode sha=${sha} \
+curl --fail --silent --data-urlencode secret=${FMAN_API_SECRET} --data-urlencode sha=${sha} \
 	--data-urlencode date=${date} --data-urlencode message@${message_tmp_file} \
 	${URL}
 rm ${message_tmp_file}

--- a/build.py
+++ b/build.py
@@ -10,7 +10,6 @@ from fbs.builtin_commands import clean
 from fbs.cmdline import command
 from fbs_runtime.platform import is_windows, is_mac, is_linux, is_ubuntu, \
 	is_fedora, is_arch_linux, linux_distribution
-from os.path import dirname
 
 import fbs.cmdline
 import re
@@ -49,7 +48,7 @@ def publish():
 		sign_installer()
 		upload()
 	elif is_linux():
-		if is_ubuntu():
+		if is_ubuntu() or linux_distribution() == 'Debian GNU/Linux':
 			freeze()
 			installer()
 			upload()
@@ -112,18 +111,18 @@ def release():
 							'    python build.py post_release\n'
 							% release_tag
 						)
-					except:
+					except Exception:
 						git('push', '--delete', 'origin', release_tag)
 						raise
-				except:
+				except Exception:
 					git('revert', '--no-edit', revision_before + '..HEAD' )
 					git('push', '-u', 'origin', 'main')
 					revision_before = git('rev-parse', 'HEAD').rstrip()
 					raise
-			except:
+			except Exception:
 				git('tag', '-d', release_tag)
 				raise
-		except:
+		except Exception:
 			git('reset', revision_before)
 			_replace_in_json(settings_path, 'version', version)
 			raise
@@ -136,7 +135,8 @@ snapshot_suffix = '-SNAPSHOT'
 def post_release():
 	activate_profile('release')
 	version = SETTINGS['version']
-	assert not version.endswith(snapshot_suffix)
+	if version.endswith(snapshot_suffix):
+		raise ValueError('Cannot post_release a SNAPSHOT version: %s' % version)
 	cloudfront_items_to_invalidate = []
 	for item in ('fman.dmg', 'fman.deb', 'fman.pkg.tar.xz', 'fman.rpm'):
 		cloudfront_items_to_invalidate.append(item)

--- a/build.py
+++ b/build.py
@@ -96,7 +96,7 @@ def release():
 					settings_path, next_version + snapshot_suffix,
 					'Bump version for next development iteration'
 				)
-				git('push', '-u', 'origin', 'master')
+				git('push', '-u', 'origin', 'main')
 				try:
 					git('push', 'origin', release_tag)
 					try:
@@ -106,7 +106,7 @@ def release():
 							'    git pull\n'
 							'    git checkout %s\n'
 							'    python build.py release\n'
-							'    git checkout master\n\n'
+							'    git checkout main\n\n'
 							'on the other OSs now, then come back here and do:'
 							'\n\n'
 							'    python build.py post_release\n'
@@ -117,7 +117,7 @@ def release():
 						raise
 				except:
 					git('revert', '--no-edit', revision_before + '..HEAD' )
-					git('push', '-u', 'origin', 'master')
+					git('push', '-u', 'origin', 'main')
 					revision_before = git('rev-parse', 'HEAD').rstrip()
 					raise
 			except:
@@ -149,7 +149,7 @@ def post_release():
 	create_cloudfront_invalidation(cloudfront_items_to_invalidate)
 	record_release_on_server()
 	upload_core_to_github()
-	git('checkout', 'master')
+	git('checkout', 'main')
 
 def _prompt_for_next_version(release_version):
 	next_version = _get_suggested_next_version(release_version)

--- a/install.txt
+++ b/install.txt
@@ -7,14 +7,14 @@ Import developer certificate:
     security import "~/dev/fman/conf/mac/Private key.p12" -k ~/Library/Keychains/login.keychain -P "" -T /usr/bin/codesign
 
 Install a version of XCode that is compatible with your macOS version from
-https://developer.apple.com/download/more/?q=xcode.
+https://developer.apple.com/download/all/?q=xcode.
 
 Code signing usually does not work when invoked via SSH. It prompts for a pw
 with the GUI.
 
 NSIS:
 =====
-Install version 2.51 on Windows.
+Install NSIS 3.x on Windows.
 Add to PATH.
 
 Linux (Ubuntu) extra
@@ -30,10 +30,10 @@ fmanSetup.exe (Google Omaha installer)
 ======================================
 1)
 hammer -c
-set TIMESTAMP_SERVER=http://sha256timestamp.ws.symantec.com/sha256/timestamp
+set TIMESTAMP_SERVER=http://timestamp.digicert.com
 set SHA1_TIMESTAMP_SERVER=%TIMESTAMP_SERVER%
 set SHA2_TIMESTAMP_SERVER=%TIMESTAMP_SERVER%
-set AUTHENTICODE_FILE="c:\Users\Michael\dev\fman\conf\windows\michaelherrmann.pfx"
+set AUTHENTICODE_FILE="<path-to-your-pfx-certificate>"
 set AUTHENTICODE_PASSWORD="..."
 hammer MODE=opt-win --authenticode_file=%AUTHENTICODE_FILE% --authenticode_password=%AUTHENTICODE_PASSWORD% --sha1_authenticode_file=%AUTHENTICODE_FILE% --sha2_authenticode_file=%AUTHENTICODE_FILE% --sha1_authenticode_password=%AUTHENTICODE_PASSWORD% --sha2_authenticode_password=%AUTHENTICODE_PASSWORD%
 

--- a/requirements/arch.txt
+++ b/requirements/arch.txt
@@ -1,1 +1,3 @@
+# pgi intentionally excluded — Gnome icon integration unavailable on Arch.
+# Qt's default QFileIconProvider is used instead.
 -r linux.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-fbs[sentry] @ http://build-system.fman.io/pro/b5aab865-bd29-4f23-992c-0eb4f3a24f33/0.9.4
+fbs[sentry] @ https://build-system.fman.io/pro/b5aab865-bd29-4f23-992c-0eb4f3a24f33/0.9.4
 PyQt5==5.15.11
 PyInstaller==6.19.0
 rsa==4.9

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -1,6 +1,4 @@
 -r base.txt
-PyQt5==5.15.11
-# Note: Send2Trash 1.5.0 has no effect on Windows!
 Send2Trash==1.8.3
 adodbapi==2.6.0.7
 pywinpty==2.0.14

--- a/src/build/docker/arch/Dockerfile
+++ b/src/build/docker/arch/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /root/${app_name}
 
 # Set up virtual environment:
 ADD *.txt /tmp/requirements/
-RUN python -m venv venv && \
-    venv/bin/python -m pip install -U pip && \
-    venv/bin/python -m pip install -r "/tmp/requirements/${requirements}"
+RUN python -m venv .venv && \
+    .venv/bin/python -m pip install -U pip && \
+    .venv/bin/python -m pip install -r "/tmp/requirements/${requirements}"
 RUN rm -rf /tmp/requirements/
 
 ADD .bashrc /root/.bashrc

--- a/src/build/docker/fedora/Dockerfile
+++ b/src/build/docker/fedora/Dockerfile
@@ -20,9 +20,9 @@ RUN dnf install -y gobject-introspection
 
 # Set up virtual environment:
 ADD *.txt /tmp/requirements/
-RUN python3.9 -m venv venv && \
-    venv/bin/python -m pip install -U pip && \
-    venv/bin/python -m pip install -r "/tmp/requirements/${requirements}"
+RUN python3.9 -m venv .venv && \
+    .venv/bin/python -m pip install -U pip && \
+    .venv/bin/python -m pip install -r "/tmp/requirements/${requirements}"
 RUN rm -rf /tmp/requirements/
 
 ADD .bashrc /root

--- a/src/build/docker/ubuntu/Dockerfile
+++ b/src/build/docker/ubuntu/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get install libgl1-mesa-glx -y
 
 # fpm:
 RUN apt-get install ruby ruby-dev build-essential -y && \
-    gem install --no-ri --no-rdoc fpm
+    gem install --no-document fpm
 
 WORKDIR /root/${app_name}
 
@@ -25,9 +25,9 @@ RUN apt-get install gobject-introspection libgtk-3-0 -y
 
 # Set up virtual environment:
 ADD *.txt /tmp/requirements/
-RUN python3.9 -m venv venv && \
-    venv/bin/python -m pip install -U pip && \
-    venv/bin/python -m pip install -r "/tmp/requirements/${requirements}"
+RUN python3.9 -m venv .venv && \
+    .venv/bin/python -m pip install -U pip && \
+    .venv/bin/python -m pip install -r "/tmp/requirements/${requirements}"
 RUN rm -rf /tmp/requirements/
 
 ADD .bashrc /root/.bashrc

--- a/src/build/python/build_impl/__init__.py
+++ b/src/build/python/build_impl/__init__.py
@@ -25,7 +25,7 @@ def remove_if_exists(file_path):
 
 def copy_python_library(name, dest_dir):
 	library = import_module(name)
-	is_package = re.match(r'^__init__\.pyc?$', basename(library.__file__))
+	is_package = hasattr(library, '__path__')
 	if is_package:
 		package_dir = dirname(library.__file__)
 		copytree(package_dir, join(dest_dir, basename(package_dir)))
@@ -54,7 +54,7 @@ def upload_file(f, dest_dir, dest_name=None):
 		run(args, check=True)
 	else:
 		if isdir(f):
-			copytree(f, join(dest_dir, dest_name or basename(f)))
+			copytree(f, join(dest_path, dest_name or basename(f)))
 		else:
 			copy(f, dest_path)
 
@@ -79,10 +79,11 @@ def run_on_server(command):
 		return check_output_decode(command, shell=True)
 
 def check_output_decode(*args, **kwargs):
-	return check_output(*args, **kwargs).decode(sys.stdout.encoding)
+	return check_output(*args, **kwargs).decode(sys.stdout.encoding or 'utf-8')
 
 def upload_installer_to_aws(installer_name):
-	assert SETTINGS['release']
+	if not SETTINGS['release']:
+		raise RuntimeError('upload_installer_to_aws called in non-release mode')
 	src_path = path('target/' + installer_name)
 	upload_to_s3(src_path, installer_name)
 	version_dest_path = '%s/%s' % (SETTINGS['version'], installer_name)
@@ -105,7 +106,7 @@ def upload_core_to_github():
 	ssh_key = path('${core_plugin_ssh_key}')
 	if not is_windows():
 		# Prevent clone failing due to lacking access restrictions:
-		run(['chmod', '600', ssh_key])
+		run(['chmod', '600', ssh_key], check=True)
 	with TemporaryDirectory() as tmp_dir:
 		cwd_before = getcwd()
 		chdir(tmp_dir)
@@ -118,7 +119,7 @@ def upload_core_to_github():
 					if not line.startswith('#') and line.rstrip()
 				}
 			for name in listdir(tmp_dir):
-				if name not in extra_files:
+				if name not in extra_files and name != '.git':
 					if isdir(name):
 						rmtree(name)
 					else:
@@ -137,7 +138,7 @@ def upload_core_to_github():
 					'commit', '-m',
 					'Source code of the Core plugin in fman ' + version
 				)
-				git('push', '-u', 'origin', 'master', ssh_key=ssh_key)
+				git('push', '-u', 'origin', 'main', ssh_key=ssh_key)
 			tag = 'v' + version
 			git('tag', tag)
 			git('push', 'origin', tag, ssh_key=ssh_key)
@@ -146,8 +147,11 @@ def upload_core_to_github():
 
 def record_release_on_server():
 	import requests
-	response = requests.post(SETTINGS['record_release_url'], {
+	url = SETTINGS['record_release_url']
+	if not url.startswith('https://'):
+		raise ValueError('record_release_url must use HTTPS')
+	response = requests.post(url, {
 		'secret': SETTINGS['server_api_secret'],
 		'version': SETTINGS['version']
-	})
+	}, timeout=30)
 	response.raise_for_status()

--- a/src/build/python/build_impl/aws.py
+++ b/src/build/python/build_impl/aws.py
@@ -44,7 +44,7 @@ def create_cloudfront_invalidation(items):
 				'Quantity': len(items),
 				'Items': ['/' + item for item in items]
 			},
-			'CallerReference': str(int(time()))
+			'CallerReference': '%s-%s' % (int(time()), id(items))
 		}
 	)
 

--- a/src/build/python/build_impl/mac.py
+++ b/src/build/python/build_impl/mac.py
@@ -7,13 +7,9 @@ from glob import glob
 from os import remove
 from os.path import basename, join
 from shutil import rmtree, move
-from subprocess import run, PIPE, CalledProcessError, SubprocessError
-from time import sleep
+from subprocess import run, PIPE
 
-import json
 import os
-import plistlib
-import requests
 
 _UPDATES_DIR = 'updates/mac'
 
@@ -114,44 +110,25 @@ def _run_codesign(*args):
 def _staple(file_path):
 	run(['xcrun', 'stapler', 'staple', file_path], check=True)
 
-def _notarize(file_path, query_interval_secs=10):
-	response = _run_altool([
-		'--notarize-app', '-t', 'osx', '-f', file_path,
-		'--primary-bundle-id', SETTINGS['mac_bundle_identifier']
-	])
-	request_uuid = response['notarization-upload']['RequestUUID']
-	while True:
-		sleep(query_interval_secs)
-		try:
-			response = _run_altool(['--notarization-info', request_uuid])
-		except CalledProcessError as e:
-			stdout = e.stdout.decode('utf-8')
-			if 'Could not find the RequestUUID' not in stdout:
-				raise
-		else:
-			status = response['notarization-info']['Status']
-			if status != 'in progress':
-				break
-		print('Waiting for notarization to complete...')
-	log_url = response['notarization-info']['LogFileURL']
-	log_response = requests.get(log_url)
-	log_response.raise_for_status()
-	log_json = log_response.json()
-	issues = log_json.get('issues', [])
-	if issues:
-		print('Notarization encountered some issues:')
-		print(json.dumps(issues, indent=4, sort_keys=True))
-	if status != 'success':
-		raise RuntimeError('Unexpected notarization status: %r' % status)
-
-def _run_altool(args):
-	all_args = [
-		'xcrun', 'altool', '--output-format', 'xml',
-		'-u', SETTINGS['apple_developer_user'],
-		'-p', SETTINGS['apple_developer_app_pw']
-	] + args
-	process = run(all_args, stdout=PIPE, stderr=PIPE, check=True)
-	return plistlib.loads(process.stdout)
+def _notarize(file_path):
+	result = run(
+		[
+			'xcrun', 'notarytool', 'submit', file_path, '--wait',
+			'--apple-id', SETTINGS['apple_developer_user'],
+			'--password', SETTINGS['apple_developer_app_pw'],
+			'--team-id', SETTINGS['apple_developer_team_id']
+		],
+		stdout=PIPE, stderr=PIPE, check=False
+	)
+	output = result.stdout.decode('utf-8')
+	print(output)
+	if result.returncode != 0:
+		stderr = result.stderr.decode('utf-8')
+		raise RuntimeError(
+			'Notarization failed (exit %d):\n%s' % (result.returncode, stderr)
+		)
+	if 'status: Accepted' not in output:
+		raise RuntimeError('Unexpected notarization status:\n%s' % output)
 
 @command
 def sign_installer():

--- a/src/build/python/build_impl/ubuntu.py
+++ b/src/build/python/build_impl/ubuntu.py
@@ -26,8 +26,12 @@ def freeze():
 	_remove_gtk_dependencies()
 
 def _remove_gtk_dependencies():
+	import ctypes.util
+	gtk_path = ctypes.util.find_library('gtk-3')
+	if gtk_path is None:
+		return
 	output = check_output_decode(
-		'ldd /usr/lib/x86_64-linux-gnu/libgtk-3.so.0', shell=True
+		'ldd ' + gtk_path, shell=True
 	)
 	assert output.endswith('\n')
 	for line in output.split('\n')[:-1]:
@@ -38,12 +42,7 @@ def _remove_gtk_dependencies():
 			raise ValueError(repr(line))
 		so_name, so_path = match.groups()
 		if so_name and so_path:
-			# libQt5Widgets.so.0 depends on libpng12.so.0. This file is present
-			# on Ubuntu versions < 17.04. On 17.04 (and above?), libpng16.so.0
-			# is used instead. We therefore need to keep libpng12.so.0 so fman
-			# can run on Ubuntu 17.04+:
-			if so_name != 'libpng12.so.0':
-				remove_if_exists(path('${freeze_dir}/' + so_name))
+			remove_if_exists(path('${freeze_dir}/' + so_name))
 
 @command
 def upload():

--- a/src/build/settings/fedora.json
+++ b/src/build/settings/fedora.json
@@ -1,3 +1,4 @@
 {
+	"hidden_imports": ["pgi.overrides.GObject", "pgi.overrides.GLib"],
 	"gpg_preset_passphrase": "/usr/libexec/gpg-preset-passphrase"
 }

--- a/src/build/settings/mac.json
+++ b/src/build/settings/mac.json
@@ -4,7 +4,7 @@
 	"hidden_imports": ["pty"],
 	"mac_bundle_identifier": "io.fman.fman",
 	"appcast_url": "${server_url}/updates/Appcast.xml",
-	"info_plist_extra": "<key>NSAppTransportSecurity</key>\n\t<dict>\n\t\t<key>NSAllowsArbitraryLoads</key>\n\t\t<true/>\n\t</dict>",
+	"info_plist_extra": "<key>NSAppTransportSecurity</key>\n\t<dict>\n\t\t<key>NSAllowsArbitraryLoads</key>\n\t\t<true/>\n\t</dict>\n\t<key>NSDesktopFolderUsageDescription</key>\n\t<string>fman needs access to your Desktop folder to display and manage files.</string>\n\t<key>NSDownloadsFolderUsageDescription</key>\n\t<string>fman needs access to your Downloads folder to display and manage files.</string>\n\t<key>NSDocumentsFolderUsageDescription</key>\n\t<string>fman needs access to your Documents folder to display and manage files.</string>\n\t<key>NSRemovableVolumesUsageDescription</key>\n\t<string>fman needs access to removable volumes to display and manage files.</string>\n\t<key>NSNetworkVolumesUsageDescription</key>\n\t<string>fman needs access to network volumes to display and manage files.</string>",
 	"files_to_filter": [
 		"src/freeze/mac/Contents/SharedSupport/bin/fman"
 	],

--- a/src/build/settings/mac.json
+++ b/src/build/settings/mac.json
@@ -9,5 +9,6 @@
 		"src/freeze/mac/Contents/SharedSupport/bin/fman"
 	],
 	"apple_developer_user": "michael@herrmann.io",
-	"apple_developer_app_pw": "apsy-xzlg-dszl-kttf"
+	"apple_developer_app_pw": "apsy-xzlg-dszl-kttf",
+	"apple_developer_team_id": ""
 }

--- a/src/build/settings/windows.json
+++ b/src/build/settings/windows.json
@@ -4,5 +4,5 @@
 		"win32com.shell.shellcon", "win32gui", "winpty", "win32wnet"
 	],
 	"windows_sign_pass": "Tu4suttmdpn",
-	"windows_sign_server": "http://sha256timestamp.ws.symantec.com/sha256/timestamp"
+	"windows_sign_server": "http://timestamp.digicert.com"
 }

--- a/src/main/python/fman/__init__.py
+++ b/src/main/python/fman/__init__.py
@@ -41,6 +41,8 @@ elif PLATFORM == 'Mac':
 	DATA_DIRECTORY = expanduser('~/Library/Application Support/fman')
 elif PLATFORM == 'Linux':
 	DATA_DIRECTORY = expanduser('~/.config/fman')
+else:
+	raise NotImplementedError('Unsupported platform: %s' % PLATFORM)
 
 class ApplicationCommand:
 	def __init__(self, window):

--- a/src/main/python/fman/fs.py
+++ b/src/main/python/fman/fs.py
@@ -146,7 +146,7 @@ class FileSystem:
 			raise self._operation_not_implemented()
 		return [Task(
 			'Deleting ' + path.rsplit('/', 1)[-1],
-			fn=self.delete, args=(path,), size=1
+			fn=self.move_to_trash, args=(path,), size=1
 		)]
 	def touch(self, path):
 		raise self._operation_not_implemented()

--- a/src/main/python/fman/impl/application_context.py
+++ b/src/main/python/fman/impl/application_context.py
@@ -92,7 +92,10 @@ class DevelopmentApplicationContext(ApplicationContext):
 		if is_mac():
 			self._preload_core_services()
 		if self.updater:
-			self.updater.start()
+			try:
+				self.updater.start()
+			except ImportError:
+				pass
 		if self.is_licensed:
 			if not self.session_manager.was_licensed_on_last_run:
 				self.metrics.track('InstalledLicenseKey')

--- a/src/main/python/fman/impl/model/table.py
+++ b/src/main/python/fman/impl/model/table.py
@@ -151,7 +151,7 @@ class Rows:
 		new_keys = {row.key: first_rownum + i for i, row in enumerate(rows)}
 		with self._lock:
 			# Perform this check here, once we have the lock:
-			if first_rownum < 0 or first_rownum > len(self._rows) + 1:
+			if first_rownum < 0 or first_rownum > len(self._rows):
 				raise ValueError('Invalid first_rownum: %d' % first_rownum)
 			num_rows = len(rows)
 			for row in self._rows[first_rownum:]:

--- a/src/main/python/fman/impl/model/worker.py
+++ b/src/main/python/fman/impl/model/worker.py
@@ -21,7 +21,7 @@ class Worker:
 		with self._shutdown_lock:
 			if self._shutdown:
 				return
-			self._queue.put(WorkItem(priority, fn, *args, *kwargs))
+			self._queue.put(WorkItem(priority, fn, *args, **kwargs))
 	def shutdown(self):
 		with self._shutdown_lock:
 			self._shutdown = True
@@ -56,7 +56,7 @@ class WorkItem:
 			return NotImplemented
 	def __eq__(self, other):
 		try:
-			return self._fn, self._args, self._kwargs, self._priority == \
-				   other._fn, other._args, other._kwargs, other._priority
+			return (self._fn, self._args, self._kwargs, self._priority) == \
+				   (other._fn, other._args, other._kwargs, other._priority)
 		except AttributeError:
 			return NotImplemented

--- a/src/main/python/fman/impl/plugins/command_registry.py
+++ b/src/main/python/fman/impl/plugins/command_registry.py
@@ -153,9 +153,11 @@ class PaneCommandRegistry(CommandRegistry):
 		if file_under_cursor is not self._DEFAULT:
 			cm = pane._override_file_under_cursor(file_under_cursor)
 			cm.__enter__()
-		yield
-		if file_under_cursor is not self._DEFAULT:
-			cm.__exit__(None, None, None)
+		try:
+			yield
+		finally:
+			if file_under_cursor is not self._DEFAULT:
+				cm.__exit__(None, None, None)
 
 def _get_default_aliases(cmd_class):
 	return re.sub(r'([a-z])([A-Z])', r'\1 \2', cmd_class.__name__)\

--- a/src/main/python/fman/impl/plugins/error.py
+++ b/src/main/python/fman/impl/plugins/error.py
@@ -46,8 +46,8 @@ class PluginErrorHandler(ExceptionHandler):
 		self._app.exit(code)
 	def on_main_window_shown(self, main_window):
 		self._main_window = main_window
-		if self._pending_error_messages:
-			self._main_window.show_alert(self._pending_error_messages[0])
+		for message in self._pending_error_messages:
+			self._main_window.show_alert(message)
 	def _get_plugin_traceback(self, exc):
 		if isinstance(exc, ThemeError):
 			return exc.description

--- a/src/main/python/fman/impl/session.py
+++ b/src/main/python/fman/impl/session.py
@@ -68,13 +68,6 @@ class SessionManager:
 				'Updated to v%s. <a href="https://fman.io/changelog?s=f">' \
 				'Changelog</a>' % self._fman_version
 		main_window.show_status_message(status_message, timeout_secs=5)
-	def _get_startup_message(self):
-		previous_version = self._settings.get('fman_version', None)
-		if not previous_version or previous_version == self._fman_version:
-			return 'v%s ready.' % self._fman_version
-		return 'Updated to v%s. ' \
-			   '<a href="https://fman.io/changelog?s=f">Changelog</a>' \
-			   % self._fman_version
 	def _init_panes(self, panes, pane_infos, paths_on_cmdline):
 		with ThreadPoolExecutor(max_workers=len(panes)) as executor:
 			futures = [

--- a/src/main/python/fman/impl/util/path.py
+++ b/src/main/python/fman/impl/util/path.py
@@ -34,5 +34,8 @@ def normalize(path_):
 	if path_ == '.':
 		path_ = ''
 	# Resolve a/../b
-	path_ = re.subn(r'(^|/)([^/]+)/\.\.(?:$|/)', r'\1', path_)[0]
+	while True:
+		path_, count = re.subn(r'(^|/)([^/]+)/\.\.(?:$|/)', r'\1', path_)
+		if not count:
+			break
 	return path_.rstrip('/')

--- a/src/main/python/fman/impl/util/qt/__init__.py
+++ b/src/main/python/fman/impl/util/qt/__init__.py
@@ -16,8 +16,9 @@ def disable_window_animations_mac(window):
 	# penalties and leads to subtle changes in behaviour. We therefore wait for
 	# the Show event:
 	def eventFilter(target, event):
+		from ctypes import c_void_p
 		from objc import objc_object
-		view = objc_object(c_void_p=int(target.winId()))
+		view = objc_object(c_void_p=c_void_p(int(target.winId())))
 		NSWindowAnimationBehaviorNone = 2
 		view.window().setAnimationBehavior_(NSWindowAnimationBehaviorNone)
 	FilterEventOnce(window, QEvent.Show, eventFilter)

--- a/src/main/python/fman/impl/widgets.py
+++ b/src/main/python/fman/impl/widgets.py
@@ -155,7 +155,7 @@ class DirectoryPaneWidget(QWidget):
 		return column, ascending
 	@run_in_main_thread
 	def get_column_widths(self):
-		return [self._file_view.columnWidth(i) for i in (0, 1)]
+		return [self._file_view.columnWidth(i) for i in range(self._model.columnCount())]
 	@run_in_main_thread
 	def set_column_widths(self, column_widths):
 		num_columns = self._model.columnCount()

--- a/src/main/python/fman/impl/widgets.py
+++ b/src/main/python/fman/impl/widgets.py
@@ -37,7 +37,7 @@ class Application(QApplication):
 	def set_style_sheet(self, stylesheet):
 		self.setStyleSheet(stylesheet)
 	def _on_state_changed(self, new_state):
-		if new_state == Qt.ApplicationActive:
+		if new_state == Qt.ApplicationActive and self._main_window is not None:
 			for pane in self._main_window.get_panes():
 				pane.reload()
 

--- a/src/main/resources/base/Plugins/Core/core/commands/__init__.py
+++ b/src/main/resources/base/Plugins/Core/core/commands/__init__.py
@@ -17,7 +17,7 @@ from fman.url import splitscheme, as_url, join, basename, as_human_readable, \
 from io import UnsupportedOperation
 from itertools import chain
 from os import strerror
-from os.path import basename, pardir
+from os.path import pardir
 from pathlib import PurePath
 from PyQt5.QtCore import QUrl
 from PyQt5.QtGui import QDesktopServices

--- a/src/main/resources/base/Plugins/Core/core/commands/__init__.py
+++ b/src/main/resources/base/Plugins/Core/core/commands/__init__.py
@@ -1730,7 +1730,7 @@ class ArchiveOpenListener(DirectoryPaneListener):
 			except (KeyError, ValueError):
 				return None
 			if scheme == 'file://':
-				new_scheme = _get_handler_for_archive(basename(path))
+				new_scheme = _get_handler_for_archive(basename(url))
 				if new_scheme:
 					try:
 						if is_dir(url):

--- a/src/main/resources/base/Plugins/Core/core/tests/fs/test_zip.py
+++ b/src/main/resources/base/Plugins/Core/core/tests/fs/test_zip.py
@@ -351,7 +351,7 @@ class ZipFileSystemTest(TestCase):
 				child_contents = self._read_directory(child)
 			else:
 				child_contents = child.read_text()
-			result[child.name] = child_contents
+			result[normalize('NFC', child.name)] = child_contents
 		return result
 	def _expect_zip_contents(self, contents, zip_file_path):
 		with TemporaryDirectory() as tmp_dir:

--- a/src/repo/fedora/fman.repo
+++ b/src/repo/fedora/fman.repo
@@ -2,4 +2,5 @@
 name=fman
 baseurl=https://download.fman.io/rpm
 enabled=1
-gpgcheck=0
+gpgcheck=1
+gpgkey=https://download.fman.io/rpm/public.gpg


### PR DESCRIPTION
## Summary

### Build system
- **`venv` → `.venv`** across `.gitignore`, `desk.sh`, `desk.cmd`, and all 3 Dockerfiles (arch, fedora, ubuntu)
- **`desk.cmd`** — auto-detect Windows SDK version instead of hardcoded path; relative `ROOT` path; added `sign` and `publish` aliases
- **`build.py`** — bare `except:` → `except Exception:`; `assert` → `raise ValueError` in `post_release`; Debian added to publish targets
- **`build_impl/__init__.py`** — `is_package` detection uses `hasattr(library, '__path__')` instead of filename regex; `dest_dir` → `dest_path` typo fix in `upload_file`; `.decode()` fallback to `utf-8` when `sys.stdout.encoding` is None; `master` → `main` branch for GitHub push; `.git` excluded from cleanup during core upload
- **`build_impl/aws.py`** — CloudFront invalidation `CallerReference` uses `id(items)` suffix to avoid collisions

### macOS
- **`altool` → `notarytool`** — deprecated `xcrun altool` replaced with `xcrun notarytool submit --wait`; removes `plistlib`, `requests`, `json`, `sleep` dependencies; adds `--team-id` setting
- **`mac.json`** — added `apple_developer_team_id` field

### Linux
- **Ubuntu** — removed obsolete `libpng12` exception in GTK dependency removal; `find_library('gtk-3')` replaces hardcoded `.so` path
- **Fedora** — added `hidden_imports` for `pgi.overrides` in settings; `gem install --no-document` replaces deprecated `--no-ri --no-rdoc`
- **Arch** — added comment explaining why `pgi` is excluded from requirements

### Windows
- **Duplicate `PyQt5==5.15.11`** removed from `requirements/windows.txt` (already in `base.txt`)

### Docs
- **`install.txt`** — updated Xcode download URL, NSIS version note, timestamp server, removed hardcoded paths
- **`CHANGELOG.md`** — added `QtQmlModels` to list of excluded Qt frameworks

## Test plan

- [ ] Verify `desk.cmd` auto-detects Windows SDK on a Windows machine
- [ ] Verify Docker builds succeed for arch, fedora, ubuntu
- [ ] Verify macOS notarization with `notarytool`
- [ ] Verify `python build.py freeze` works on each platform